### PR TITLE
Handle incorrect passwords in PDF unlocker

### DIFF
--- a/app/unlock.py
+++ b/app/unlock.py
@@ -47,44 +47,39 @@ class PDFUnlocker:
         if out_path is None:
             out_path = os.path.join(self.temp_dir, self._out_name(src_pdf))
 
+        doc = None
         try:
             # PDF'i PyMuPDF ile aç
             doc = fitz.open(src_pdf)
-            
+
             # PDF şifreli mi kontrol et
             was_encrypted = doc.needs_pass
-            
+
             if was_encrypted:
-                # Şifreyi dene
-                try:
-                    doc.authenticate(password)
-                except Exception as e:
-                    doc.close()
-                    raise PDFUnlockError(f"Şifre yanlış: {str(e)}")
-                
-                # Şifreli PDF'i şifresiz olarak kaydet
+                if not doc.authenticate(password):
+                    raise PDFUnlockError("Şifre yanlış")
                 doc.save(out_path, encryption=fitz.PDF_ENCRYPT_NONE)
             else:
-                # Şifresiz PDF'i kopyala
                 doc.save(out_path)
-            
-            doc.close()
-
-            # Dosyanın gerçekten oluşturulduğunu kontrol et
-            if not os.path.exists(out_path):
-                raise PDFUnlockError("Şifresi kaldırılmış PDF oluşturulamadı")
-
-            return UnlockResult(
-                output_path=out_path, 
-                unlocked=True, 
-                was_encrypted=was_encrypted
-            )
 
         except PDFUnlockError:
             raise
         except Exception as e:
             logger.error(f"PDF şifre kaldırma hatası: {e}")
             raise PDFUnlockError(f"PDF şifre kaldırma sırasında hata oluştu: {str(e)}")
+        finally:
+            if doc:
+                doc.close()
+
+        # Dosyanın gerçekten oluşturulduğunu kontrol et
+        if not os.path.exists(out_path):
+            raise PDFUnlockError("Şifresi kaldırılmış PDF oluşturulamadı")
+
+        return UnlockResult(
+            output_path=out_path,
+            unlocked=True,
+            was_encrypted=was_encrypted
+        )
 
     def check_encryption(self, pdf_path: str) -> bool:
         """PDF'in şifreli olup olmadığını kontrol et"""

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -101,10 +101,14 @@ class PerformanceMonitor {
     init() {
         if ('performance' in window) {
             window.addEventListener('load', () => {
-                const perfData = window.performance.timing;
-                const pageLoadTime = perfData.loadEventEnd - perfData.navigationStart;
-                
-                this.trackEvent('page_load', { load_time: pageLoadTime });
+                setTimeout(() => {
+                    const navEntry = performance.getEntriesByType('navigation')[0];
+                    const pageLoadTime = navEntry ? navEntry.loadEventEnd : 0;
+                    if (pageLoadTime < 0) {
+                        window.disableAutoScroll = true;
+                    }
+                    this.trackEvent('page_load', { load_time: pageLoadTime });
+                }, 0);
             });
         }
     }

--- a/site/js/tools/unlock.js
+++ b/site/js/tools/unlock.js
@@ -68,7 +68,7 @@ class UnlockTool {
                 </div>
             </div>
             <div class="flex justify-center">
-                <button onclick="this.downloadFile('${pdfApi.getUnlockDownloadUrl(result.session_id, result.output_file)}')" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg mr-3 transition">
+                <button onclick="downloadFile('${pdfApi.getUnlockDownloadUrl(result.session_id, result.output_file)}')" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg mr-3 transition">
                     <i class="fas fa-download mr-2"></i>Tekrar İndir
                 </button>
                 <button id="resetToolButton" class="bg-gray-200 hover:bg-gray-300 text-gray-800 px-6 py-2 rounded-lg transition">
@@ -80,7 +80,7 @@ class UnlockTool {
             </div>
         `;
         resultArea.classList.remove('hidden');
-        
+
         // Download function ekle
         window.downloadFile = (url) => {
             const link = document.createElement('a');
@@ -90,6 +90,9 @@ class UnlockTool {
             link.click();
             document.body.removeChild(link);
         };
+
+        // Otomatik indirmeyi başlat
+        window.downloadFile(`${pdfApi.getUnlockDownloadUrl(result.session_id, result.output_file)}`);
     }
 
     getOptions(){

--- a/site/scroll-manager.js
+++ b/site/scroll-manager.js
@@ -11,12 +11,12 @@ if (isReload) {
     if ('scrollRestoration' in history) {
         history.scrollRestoration = 'manual';
     }
-    // Sadece bu yüklemede en üste al
-    window.addEventListener('DOMContentLoaded', () => {
-        setTimeout(() => window.scrollTo(0, 0), 0);
-    }, { once: true });
     window.addEventListener('load', () => {
-        window.scrollTo(0, 0);
+        setTimeout(() => {
+            if (!window.disableAutoScroll) {
+                window.scrollTo(0, 0);
+            }
+        }, 0);
     }, { once: true });
 }
 


### PR DESCRIPTION
## Summary
- validate password during PDF unlock and raise explicit error
- ensure PDF documents are closed in all cases
- fix unlock tool download button and trigger automatic download
- compute page load time using navigation timing to avoid negative values and disable auto-scroll on anomalies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1ebdffe448327be0721d9e7b1c26c