### PR TITLE
Enable multi-PDF support for all PDF tools

### DIFF
--- a/app/routers/pdf_to_jpg.py
+++ b/app/routers/pdf_to_jpg.py
@@ -16,15 +16,29 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/tools/pdf-to-jpg", tags=["pdf-to-jpg"])
 
 @router.post("/upload")
-async def upload_pdf_for_jpg(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_jpg(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
+
+    total_size = 0
+    uploaded: list[dict] = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -37,26 +51,47 @@ async def process_pdf_to_jpg(session_id: str, dpi: int = 200):
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
-    pdf_files = list(Path(session_dir).glob("*.pdf"))
-    if not pdf_files:
+
+    files = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    if not files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdf_files[0])
+
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+
+    pdf_files = sorted(files, key=_upload_index_key)
+
     converter = PDFToJPGConverter(temp_dir=session_dir)
-    images = converter.convert(input_pdf, session_dir, dpi)
+    images: list[str] = []
+    for src in pdf_files:
+        try:
+            imgs = converter.convert(src, session_dir, dpi)
+            images.extend(os.path.basename(i) for i in imgs)
+        except Exception as e:
+            logger.error(f"PDF→JPG failed for {src}: {e}")
+            continue
+
+    if not images:
+        raise HTTPException(status_code=500, detail="Dönüştürme sırasında hata oluştu")
+
+    zip_name = None
     if len(images) > 1:
         zip_name = f"images_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
         zip_path = os.path.join(session_dir, zip_name)
         with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
             for img in images:
-                zf.write(img, arcname=os.path.basename(img))
-        output_file = zip_name
-    else:
-        output_file = os.path.basename(images[0])
+                zf.write(os.path.join(session_dir, img), arcname=img)
+
     return {
         "success": True,
         "session_id": session_id,
-        "output_file": output_file,
-        "download_url": f"/api/tools/pdf-to-jpg/download/{session_id}/{output_file}",
+        "results": images,
+        "zip_file": zip_name,
+        "download_url": f"/api/tools/pdf-to-jpg/download/{session_id}/{zip_name}" if zip_name else f"/api/tools/pdf-to-jpg/download/{session_id}/{images[0]}",
     }
 
 @router.get("/download/{session_id}/{filename}")

--- a/app/routers/pdf_to_ppt.py
+++ b/app/routers/pdf_to_ppt.py
@@ -18,16 +18,29 @@ router = APIRouter(prefix="/api/tools/pdf-to-ppt", tags=["pdf-to-ppt"])
 
 
 @router.post("/upload")
-async def upload_pdf_for_ppt(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_ppt(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    total_size = 0
+    uploaded: list[dict] = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -42,27 +55,54 @@ async def process_pdf_to_ppt(session_id: str):
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
 
-    pdfs = list(Path(session_dir).glob("*.pdf"))
-    if not pdfs:
+    files = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    if not files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdfs[0])
+
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+
+    pdf_files = sorted(files, key=_upload_index_key)
 
     converter = PDFToPPTConverter(temp_dir=session_dir)
-    try:
-        result = converter.convert(input_pdf)
-        output_name = os.path.basename(result.output_path)
-        return {
-            "success": True,
-            "session_id": session_id,
-            "output_file": output_name,
-            "page_count": result.page_count,
-            "download_url": f"/api/tools/pdf-to-ppt/download/{session_id}/{output_name}",
-        }
-    except PDFToPPTError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"PDF→PPT process error: {e}")
+    outputs: list[str] = []
+    page_counts: list[int] = []
+    for src in pdf_files:
+        try:
+            result = converter.convert(src)
+            outputs.append(os.path.basename(result.output_path))
+            page_counts.append(result.page_count)
+        except PDFToPPTError as e:
+            logger.error(f"PDF→PPT failed for {src}: {e}")
+            continue
+        except Exception as e:
+            logger.error(f"PDF→PPT process error for {src}: {e}")
+            continue
+
+    if not outputs:
         raise HTTPException(status_code=500, detail="Dönüştürme sırasında hata oluştu")
+
+    zip_name = None
+    if len(outputs) > 1:
+        import zipfile
+        zip_name = f"converted_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for o in outputs:
+                zf.write(os.path.join(session_dir, o), arcname=o)
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "results": outputs,
+        "page_counts": page_counts,
+        "zip_file": zip_name,
+        "download_url": f"/api/tools/pdf-to-ppt/download/{session_id}/{zip_name}" if zip_name else f"/api/tools/pdf-to-ppt/download/{session_id}/{outputs[0]}",
+    }
 
 
 @router.get("/download/{session_id}/{filename}")

--- a/app/routers/pdf_to_word.py
+++ b/app/routers/pdf_to_word.py
@@ -18,16 +18,29 @@ router = APIRouter(prefix="/api/tools/pdf-to-word", tags=["pdf-to-word"])
 
 
 @router.post("/upload")
-async def upload_pdf_for_convert(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_convert(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    total_size = 0
+    uploaded: list[dict] = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -42,26 +55,51 @@ async def process_pdf_to_word(session_id: str):
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
 
-    pdf_files = list(Path(session_dir).glob("*.pdf"))
-    if not pdf_files:
+    files = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    if not files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdf_files[0])
+
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+
+    pdf_files = sorted(files, key=_upload_index_key)
 
     converter = PDFToWordConverter(temp_dir=session_dir)
-    try:
-        result = converter.convert(input_pdf)
-        output_name = os.path.basename(result.output_path)
-        return {
-            "success": True,
-            "session_id": session_id,
-            "output_file": output_name,
-            "download_url": f"/api/tools/pdf-to-word/download/{session_id}/{output_name}",
-        }
-    except PDFToWordError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"PDF→Word process error: {e}")
+    outputs: list[str] = []
+    for src in pdf_files:
+        try:
+            result = converter.convert(src)
+            outputs.append(os.path.basename(result.output_path))
+        except PDFToWordError as e:
+            logger.error(f"PDF→Word failed for {src}: {e}")
+            continue
+        except Exception as e:
+            logger.error(f"PDF→Word process error for {src}: {e}")
+            continue
+
+    if not outputs:
         raise HTTPException(status_code=500, detail="Dönüştürme sırasında hata oluştu")
+
+    zip_name = None
+    if len(outputs) > 1:
+        import zipfile
+        zip_name = f"converted_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for o in outputs:
+                zf.write(os.path.join(session_dir, o), arcname=o)
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "results": outputs,
+        "zip_file": zip_name,
+        "download_url": f"/api/tools/pdf-to-word/download/{session_id}/{zip_name}" if zip_name else f"/api/tools/pdf-to-word/download/{session_id}/{outputs[0]}",
+    }
 
 
 @router.get("/download/{session_id}/{filename}")

--- a/app/routers/protect.py
+++ b/app/routers/protect.py
@@ -18,16 +18,29 @@ router = APIRouter(prefix="/api/tools/protect", tags=["protect"])
 
 
 @router.post("/upload")
-async def upload_pdf_for_protect(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_protect(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    total_size = 0
+    uploaded: list[dict] = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -54,12 +67,19 @@ async def process_pdf_protect(
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
 
-    pdfs = list(Path(session_dir).glob("*.pdf"))
-    if not pdfs:
+    files = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    if not files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdfs[0])
 
-    # Şifreleme seçeneklerini oluştur
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+
+    pdf_files = sorted(files, key=_upload_index_key)
+
     options = ProtectionOptions(
         user_password=user_password,
         owner_password=owner_password if owner_password else None,
@@ -70,25 +90,41 @@ async def process_pdf_protect(
         can_fill_forms=can_fill_forms,
         can_accessibility=can_accessibility,
         can_assemble=can_assemble,
-        can_modify_contents=can_modify_contents
+        can_modify_contents=can_modify_contents,
     )
 
     protector = PDFProtector(temp_dir=session_dir)
+    results: list[dict] = []
     try:
-        result = protector.protect(input_pdf, options)
-        output_name = os.path.basename(result.output_path)
-        return {
-            "success": True,
-            "session_id": session_id,
-            "output_file": output_name,
-            "protected": result.protected,
-            "download_url": f"/api/tools/protect/download/{session_id}/{output_name}",
-        }
+        for src in pdf_files:
+            res = protector.protect(src, options)
+            out_name = os.path.basename(res.output_path)
+            results.append({"output_file": out_name, "protected": res.protected})
     except PDFProtectError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"PDF→Protect process error: {e}")
         raise HTTPException(status_code=500, detail="Şifreleme sırasında hata oluştu")
+
+    if not results:
+        raise HTTPException(status_code=500, detail="Şifreleme sırasında hata oluştu")
+
+    zip_name = None
+    if len(results) > 1:
+        import zipfile
+        zip_name = f"protected_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for r in results:
+                zf.write(os.path.join(session_dir, r["output_file"]), arcname=r["output_file"])
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "results": results,
+        "zip_file": zip_name,
+        "download_url": f"/api/tools/protect/download/{session_id}/{zip_name}" if zip_name else f"/api/tools/protect/download/{session_id}/{results[0]['output_file']}",
+    }
 
 
 @router.get("/download/{session_id}/{filename}")

--- a/app/routers/rotate.py
+++ b/app/routers/rotate.py
@@ -15,15 +15,29 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/tools/rotate", tags=["rotate"])
 
 @router.post("/upload")
-async def upload_pdf_for_rotate(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_rotate(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
+
+    total_size = 0
+    uploaded: list[dict] = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -36,19 +50,50 @@ async def process_rotate(session_id: str, degrees: int = 90):
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
-    pdf_files = list(Path(session_dir).glob("*.pdf"))
-    if not pdf_files:
+
+    files = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    if not files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdf_files[0])
-    output_name = f"rotated_{pdf_files[0].name}"
-    output_path = os.path.join(session_dir, output_name)
+
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+
+    pdf_files = sorted(files, key=_upload_index_key)
+
     rotator = PDFRotator(temp_dir=session_dir)
-    rotator.rotate(input_pdf, output_path, degrees)
+    outputs: list[str] = []
+    for src in pdf_files:
+        output_name = f"rotated_{Path(src).name}"
+        output_path = os.path.join(session_dir, output_name)
+        try:
+            rotator.rotate(src, output_path, degrees)
+            outputs.append(output_name)
+        except Exception as e:
+            logger.error(f"Rotate failed for {src}: {e}")
+            continue
+
+    if not outputs:
+        raise HTTPException(status_code=500, detail="Döndürme sırasında hata oluştu")
+
+    zip_name = None
+    if len(outputs) > 1:
+        import zipfile
+        zip_name = f"rotated_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for o in outputs:
+                zf.write(os.path.join(session_dir, o), arcname=o)
+
     return {
         "success": True,
         "session_id": session_id,
-        "output_file": output_name,
-        "download_url": f"/api/tools/rotate/download/{session_id}/{output_name}",
+        "results": outputs,
+        "zip_file": zip_name,
+        "download_url": f"/api/tools/rotate/download/{session_id}/{zip_name}" if zip_name else f"/api/tools/rotate/download/{session_id}/{outputs[0]}",
     }
 
 @router.get("/download/{session_id}/{filename}")

--- a/app/routers/split.py
+++ b/app/routers/split.py
@@ -19,19 +19,29 @@ router = APIRouter(prefix="/api/tools/split", tags=["split"])
 
 
 @router.post("/upload")
-async def upload_pdf_for_split(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_split(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    total_size = 0
+    uploaded: list[dict] = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {
-            "session_id": session_id,
-            "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)},
-        }
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             shutil.rmtree(session_dir)
@@ -50,39 +60,64 @@ async def process_split(
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
 
-    pdf_files = list(Path(session_dir).glob("*.pdf"))
-    if not pdf_files:
+    files = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    if not files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdf_files[0])
+
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+
+    pdf_files = sorted(files, key=_upload_index_key)
+
+    if mode == "ranges" and not pages:
+        raise HTTPException(status_code=400, detail="Sayfa aralıkları boş olamaz")
+    if mode == "every_n" and not every_n:
+        raise HTTPException(status_code=400, detail="Aralık değeri gerekli")
+    if mode not in {"ranges", "every_n"}:
+        raise HTTPException(status_code=400, detail="Geçersiz mod")
 
     splitter = PDFSplitter(temp_dir=session_dir)
+    outputs: list[str] = []
     try:
-        if mode == "ranges":
-            if not pages:
-                raise HTTPException(status_code=400, detail="Sayfa aralıkları boş olamaz")
-            result = splitter.split_by_ranges(input_pdf, pages)
-        elif mode == "every_n":
-            if not every_n:
-                raise HTTPException(status_code=400, detail="Aralık değeri gerekli")
-            result = splitter.split_every_n(input_pdf, int(every_n))
-        else:
-            raise HTTPException(status_code=400, detail="Geçersiz mod")
+        for src in pdf_files:
+            if mode == "ranges":
+                result = splitter.split_by_ranges(src, pages)
+            else:
+                result = splitter.split_every_n(src, int(every_n))
 
-        output_files = [os.path.basename(p) for p in result.output_files]
-        zip_name = os.path.basename(result.zip_path) if result.zip_path else None
-
-        return {
-            "success": True,
-            "session_id": session_id,
-            "outputs": output_files,
-            "zip_file": zip_name,
-            "download_url": f"/api/tools/split/download/{session_id}/{zip_name}" if zip_name else None,
-        }
+            outputs.extend(os.path.basename(p) for p in result.output_files)
+            if result.zip_path:
+                try:
+                    os.remove(result.zip_path)
+                except Exception:
+                    pass
     except PDFSplitError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Split process error: {e}")
         raise HTTPException(status_code=500, detail="PDF ayırma sırasında hata oluştu")
+
+    if not outputs:
+        raise HTTPException(status_code=500, detail="PDF ayırma sırasında hata oluştu")
+
+    import zipfile
+    zip_name = f"split_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+    zip_path = os.path.join(session_dir, zip_name)
+    with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for o in outputs:
+            zf.write(os.path.join(session_dir, o), arcname=o)
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "outputs": outputs,
+        "zip_file": zip_name,
+        "download_url": f"/api/tools/split/download/{session_id}/{zip_name}",
+    }
 
 
 @router.get("/download/{session_id}/{filename}")

--- a/app/routers/unlock.py
+++ b/app/routers/unlock.py
@@ -18,16 +18,29 @@ router = APIRouter(prefix="/api/tools/unlock", tags=["unlock"])
 
 
 @router.post("/upload")
-async def upload_pdf_for_unlock(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_unlock(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    total_size = 0
+    uploaded: list[dict] = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -45,28 +58,51 @@ async def process_pdf_unlock(
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
 
-    pdfs = list(Path(session_dir).glob("*.pdf"))
-    if not pdfs:
+    files = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    if not files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdfs[0])
+
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+
+    pdf_files = sorted(files, key=_upload_index_key)
 
     unlocker = PDFUnlocker(temp_dir=session_dir)
+    results: list[dict] = []
     try:
-        result = unlocker.unlock(input_pdf, password)
-        output_name = os.path.basename(result.output_path)
-        return {
-            "success": True,
-            "session_id": session_id,
-            "output_file": output_name,
-            "unlocked": result.unlocked,
-            "was_encrypted": result.was_encrypted,
-            "download_url": f"/api/tools/unlock/download/{session_id}/{output_name}",
-        }
+        for src in pdf_files:
+            res = unlocker.unlock(src, password)
+            out_name = os.path.basename(res.output_path)
+            results.append({"output_file": out_name, "unlocked": res.unlocked, "was_encrypted": res.was_encrypted})
     except PDFUnlockError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"PDF→Unlock process error: {e}")
         raise HTTPException(status_code=500, detail="Şifre kaldırma sırasında hata oluştu")
+
+    if not results:
+        raise HTTPException(status_code=500, detail="Şifre kaldırma sırasında hata oluştu")
+
+    zip_name = None
+    if len(results) > 1:
+        import zipfile
+        zip_name = f"unlocked_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for r in results:
+                zf.write(os.path.join(session_dir, r["output_file"]), arcname=r["output_file"])
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "results": results,
+        "zip_file": zip_name,
+        "download_url": f"/api/tools/unlock/download/{session_id}/{zip_name}" if zip_name else f"/api/tools/unlock/download/{session_id}/{results[0]['output_file']}",
+    }
 
 
 @router.get("/download/{session_id}/{filename}")

--- a/app/routers/watermark.py
+++ b/app/routers/watermark.py
@@ -15,15 +15,28 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/tools/watermark", tags=["watermark"])
 
 @router.post("/upload")
-async def upload_pdf_for_watermark(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_watermark(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
+    total_size = 0
+    uploaded: list[dict] = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -42,19 +55,48 @@ async def process_watermark(
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
-    pdf_files = list(Path(session_dir).glob("*.pdf"))
-    if not pdf_files:
+    files = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    if not files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdf_files[0])
-    output_name = f"watermarked_{pdf_files[0].name}"
-    output_path = os.path.join(session_dir, output_name)
+
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+
+    pdf_files = sorted(files, key=_upload_index_key)
     watermarker = PDFWatermarker(temp_dir=session_dir)
-    watermarker.add_text_watermark(input_pdf, output_path, text, position, font_size, color)
+    outputs: list[str] = []
+    for src in pdf_files:
+        output_name = f"watermarked_{Path(src).name}"
+        output_path = os.path.join(session_dir, output_name)
+        try:
+            watermarker.add_text_watermark(src, output_path, text, position, font_size, color)
+            outputs.append(output_name)
+        except Exception as e:
+            logger.error(f"Watermark failed for {src}: {e}")
+            continue
+
+    if not outputs:
+        raise HTTPException(status_code=500, detail="Filigran ekleme sırasında hata oluştu")
+
+    zip_name = None
+    if len(outputs) > 1:
+        import zipfile
+        zip_name = f"watermarked_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for o in outputs:
+                zf.write(os.path.join(session_dir, o), arcname=o)
+
     return {
         "success": True,
         "session_id": session_id,
-        "output_file": output_name,
-        "download_url": f"/api/tools/watermark/download/{session_id}/{output_name}",
+        "results": outputs,
+        "zip_file": zip_name,
+        "download_url": f"/api/tools/watermark/download/{session_id}/{zip_name}" if zip_name else f"/api/tools/watermark/download/{session_id}/{outputs[0]}",
     }
 
 @router.get("/download/{session_id}/{filename}")


### PR DESCRIPTION
## Summary
- Allow uploading multiple PDFs across conversion and editing endpoints
- Iterate over uploaded PDFs and return zipped results when necessary

## Testing
- `pytest`
- `python -m py_compile app/routers/pdf_to_word.py app/routers/pdf_to_jpg.py app/routers/pdf_to_ppt.py app/routers/split.py app/routers/protect.py app/routers/unlock.py app/routers/rotate.py app/routers/watermark.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2a044688c8327bd17f7b8df80de42