### PR TITLE
Enable multi-file processing for rotate, protect and watermark tools

### DIFF
--- a/app/routers/protect.py
+++ b/app/routers/protect.py
@@ -18,22 +18,35 @@ router = APIRouter(prefix="/api/tools/protect", tags=["protect"])
 
 
 @router.post("/upload")
-async def upload_pdf_for_protect(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_protect(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    total_size = 0
+    uploaded = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
             shutil.rmtree(session_dir)
         logger.error(f"PDF→Protect upload failed: {e}")
-        raise HTTPException(status_code=500, detail="Dosya yükleme sırasında hata oluştu")
+        raise
 
 
 @router.post("/process/{session_id}")
@@ -54,10 +67,16 @@ async def process_pdf_protect(
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
 
-    pdfs = list(Path(session_dir).glob("*.pdf"))
-    if not pdfs:
+    pdfs = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+    pdf_files = sorted(pdfs, key=_upload_index_key)
+    if not pdf_files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdfs[0])
 
     # Şifreleme seçeneklerini oluştur
     options = ProtectionOptions(
@@ -74,21 +93,39 @@ async def process_pdf_protect(
     )
 
     protector = PDFProtector(temp_dir=session_dir)
+    outputs = []
     try:
-        result = protector.protect(input_pdf, options)
-        output_name = os.path.basename(result.output_path)
-        return {
-            "success": True,
-            "session_id": session_id,
-            "output_file": output_name,
-            "protected": result.protected,
-            "download_url": f"/api/tools/protect/download/{session_id}/{output_name}",
-        }
+        for src in pdf_files:
+            result = protector.protect(src, options)
+            outputs.append({
+                "input": os.path.basename(src),
+                "output": os.path.basename(result.output_path),
+                "protected": result.protected,
+            })
     except PDFProtectError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"PDF→Protect process error: {e}")
         raise HTTPException(status_code=500, detail="Şifreleme sırasında hata oluştu")
+
+    zip_name = None
+    if len(outputs) > 1:
+        import zipfile
+        zip_name = f"protected_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for o in outputs:
+                zf.write(os.path.join(session_dir, o["output"]), arcname=o["output"])
+
+    download_url = f"/api/tools/protect/download/{session_id}/{zip_name}" if zip_name else f"/api/tools/protect/download/{session_id}/{outputs[0]['output']}"
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "results": outputs,
+        "zip_file": zip_name,
+        "download_url": download_url,
+    }
 
 
 @router.get("/download/{session_id}/{filename}")
@@ -97,4 +134,5 @@ async def download_protected_pdf(session_id: str, filename: str):
     file_path = os.path.join(session_dir, filename)
     if not os.path.exists(file_path):
         raise HTTPException(status_code=404, detail="Dosya bulunamadı")
-    return FileResponse(path=file_path, media_type="application/pdf", filename=filename)
+    media = "application/zip" if filename.lower().endswith('.zip') else "application/pdf"
+    return FileResponse(path=file_path, media_type=media, filename=filename)

--- a/app/routers/rotate.py
+++ b/app/routers/rotate.py
@@ -15,40 +15,78 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/tools/rotate", tags=["rotate"])
 
 @router.post("/upload")
-async def upload_pdf_for_rotate(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_rotate(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
+
+    total_size = 0
+    uploaded = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
             shutil.rmtree(session_dir)
         logger.error(f"Rotate upload failed: {e}")
-        raise HTTPException(status_code=500, detail="Dosya yükleme sırasında hata oluştu")
+        raise
 
 @router.post("/process/{session_id}")
 async def process_rotate(session_id: str, degrees: int = 90):
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
-    pdf_files = list(Path(session_dir).glob("*.pdf"))
+
+    files = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+    pdf_files = sorted(files, key=_upload_index_key)
     if not pdf_files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdf_files[0])
-    output_name = f"rotated_{pdf_files[0].name}"
-    output_path = os.path.join(session_dir, output_name)
+
     rotator = PDFRotator(temp_dir=session_dir)
-    rotator.rotate(input_pdf, output_path, degrees)
+    outputs = []
+    for src in pdf_files:
+        out_name = f"rotated_{Path(src).name}"
+        out_path = os.path.join(session_dir, out_name)
+        rotator.rotate(src, out_path, degrees)
+        outputs.append({"input": os.path.basename(src), "output": out_name})
+
+    zip_name = None
+    if len(outputs) > 1:
+        import zipfile
+        zip_name = f"rotated_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for o in outputs:
+                zf.write(os.path.join(session_dir, o["output"]), arcname=o["output"])
+
+    download_url = f"/api/tools/rotate/download/{session_id}/{zip_name}" if zip_name else f"/api/tools/rotate/download/{session_id}/{outputs[0]['output']}"
+
     return {
         "success": True,
         "session_id": session_id,
-        "output_file": output_name,
-        "download_url": f"/api/tools/rotate/download/{session_id}/{output_name}",
+        "results": outputs,
+        "zip_file": zip_name,
+        "download_url": download_url,
     }
 
 @router.get("/download/{session_id}/{filename}")
@@ -57,4 +95,5 @@ async def download_rotated(session_id: str, filename: str):
     file_path = os.path.join(session_dir, filename)
     if not os.path.exists(file_path):
         raise HTTPException(status_code=404, detail="Dosya bulunamadı")
-    return FileResponse(path=file_path, media_type="application/pdf", filename=filename)
+    media = "application/zip" if filename.lower().endswith('.zip') else "application/pdf"
+    return FileResponse(path=file_path, media_type=media, filename=filename)

--- a/app/routers/watermark.py
+++ b/app/routers/watermark.py
@@ -15,21 +15,35 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/tools/watermark", tags=["watermark"])
 
 @router.post("/upload")
-async def upload_pdf_for_watermark(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdfs_for_watermark(files: list[UploadFile] = File(...)):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
+
+    total_size = 0
+    uploaded = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(status_code=400, detail=f"Toplam boyut {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor")
+            path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, path)
+            uploaded.append({"original_name": file.filename, "path": str(path), "size": getattr(file, "size", 0)})
+        return {"session_id": session_id, "files": uploaded}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
             shutil.rmtree(session_dir)
         logger.error(f"Watermark upload failed: {e}")
-        raise HTTPException(status_code=500, detail="Dosya yükleme sırasında hata oluştu")
+        raise
 
 @router.post("/process/{session_id}")
 async def process_watermark(
@@ -42,19 +56,42 @@ async def process_watermark(
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
-    pdf_files = list(Path(session_dir).glob("*.pdf"))
+    files = [str(p) for p in Path(session_dir).glob("*.pdf")]
+    def _upload_index_key(p: str) -> int:
+        name = Path(p).name
+        parts = name.split('_', 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            return int(parts[0])
+        return 0
+    pdf_files = sorted(files, key=_upload_index_key)
     if not pdf_files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdf_files[0])
-    output_name = f"watermarked_{pdf_files[0].name}"
-    output_path = os.path.join(session_dir, output_name)
+
     watermarker = PDFWatermarker(temp_dir=session_dir)
-    watermarker.add_text_watermark(input_pdf, output_path, text, position, font_size, color)
+    outputs = []
+    for src in pdf_files:
+        out_name = f"watermarked_{Path(src).name}"
+        out_path = os.path.join(session_dir, out_name)
+        watermarker.add_text_watermark(src, out_path, text, position, font_size, color)
+        outputs.append({"input": os.path.basename(src), "output": out_name})
+
+    zip_name = None
+    if len(outputs) > 1:
+        import zipfile
+        zip_name = f"watermarked_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for o in outputs:
+                zf.write(os.path.join(session_dir, o["output"]), arcname=o["output"])
+
+    download_url = f"/api/tools/watermark/download/{session_id}/{zip_name}" if zip_name else f"/api/tools/watermark/download/{session_id}/{outputs[0]['output']}"
+
     return {
         "success": True,
         "session_id": session_id,
-        "output_file": output_name,
-        "download_url": f"/api/tools/watermark/download/{session_id}/{output_name}",
+        "results": outputs,
+        "zip_file": zip_name,
+        "download_url": download_url,
     }
 
 @router.get("/download/{session_id}/{filename}")
@@ -63,4 +100,5 @@ async def download_watermarked(session_id: str, filename: str):
     file_path = os.path.join(session_dir, filename)
     if not os.path.exists(file_path):
         raise HTTPException(status_code=404, detail="Dosya bulunamadı")
-    return FileResponse(path=file_path, media_type="application/pdf", filename=filename)
+    media = "application/zip" if filename.lower().endswith('.zip') else "application/pdf"
+    return FileResponse(path=file_path, media_type=media, filename=filename)

--- a/site/js/modules/api.js
+++ b/site/js/modules/api.js
@@ -249,9 +249,9 @@ class PDFApi {
     }
 
     // ===== PDF Şifreleme APIs =====
-    async uploadFileForProtect(file) {
+    async uploadFilesForProtect(files) {
         const formData = new FormData();
-        formData.append('file', file);
+        files.forEach(f => formData.append('files', f));
         const response = await fetch(`${this.baseUrl}/tools/protect/upload`, { method: 'POST', body: formData });
         if (!response.ok) {
             const err = await response.json().catch(() => ({}));
@@ -315,9 +315,9 @@ class PDFApi {
     }
 
     // ===== Rotate APIs =====
-    async uploadFileForRotate(file) {
+    async uploadFilesForRotate(files) {
         const formData = new FormData();
-        formData.append('file', file);
+        files.forEach(f => formData.append('files', f));
         const res = await fetch(`${this.baseUrl}/tools/rotate/upload`, { method: 'POST', body: formData });
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));
@@ -340,9 +340,9 @@ class PDFApi {
     }
 
     // ===== Watermark APIs =====
-    async uploadFileForWatermark(file) {
+    async uploadFilesForWatermark(files) {
         const formData = new FormData();
-        formData.append('file', file);
+        files.forEach(f => formData.append('files', f));
         const res = await fetch(`${this.baseUrl}/tools/watermark/upload`, { method: 'POST', body: formData });
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));

--- a/site/js/tools/protect.js
+++ b/site/js/tools/protect.js
@@ -11,10 +11,8 @@ class ProtectTool {
 
     async process(){
         const files = fileHandler.getSelectedFiles();
-        if (files.length !== 1) { 
-            notifications.error('Lütfen tek bir PDF yükleyin'); 
-            return; 
-        }
+        if (files.length < 1){ notifications.error('En az 1 PDF yükleyin'); return; }
+        if (files.length > 10){ notifications.error('Maksimum 10 dosya'); return; }
 
         const btn = document.getElementById('processButton');
         if (btn) btn.disabled = true;
@@ -27,8 +25,8 @@ class ProtectTool {
                 return;
             }
 
-            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `Dosya yükleniyor` });
-            const up = await pdfApi.uploadFileForProtect(files[0]);
+            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `${files.length} dosya yükleniyor` });
+            const up = await pdfApi.uploadFilesForProtect(files);
             const sessionId = up.session_id;
 
             pdfLoader.updateProgress(50, 'PDF şifreleniyor...');
@@ -70,8 +68,8 @@ class ProtectTool {
     showResult(result){
         const resultArea = document.getElementById('resultArea');
         if (!resultArea) return;
-        
-        const url = pdfApi.getProtectDownloadUrl(result.session_id, result.output_file);
+
+        const url = window.location.origin + result.download_url;
         fileHandler.triggerFileDownload(url);
 
         const downloadBtn = resultArea.querySelector('button');
@@ -150,8 +148,8 @@ class ProtectTool {
         return 'PDF artık güvenli! 🔐 Şifreler sizin, gizlilik bizim!'; 
     }
     
-    getDescription(){ 
-        return "PDF dosyalarınıza güçlü şifre koruması ekleyin; kullanıcı izinlerini özelleştirin."; 
+    getDescription(){
+        return "PDF dosyalarınıza güçlü şifre koruması ekleyin; birden fazlaysa ZIP olarak indirin.";
     }
 }
 

--- a/site/js/tools/rotate.js
+++ b/site/js/tools/rotate.js
@@ -11,15 +11,13 @@ class RotateTool {
 
     async process(){
         const files = fileHandler.getSelectedFiles();
-        if (files.length !== 1){
-            notifications.error('Lütfen tek bir PDF yükleyin');
-            return;
-        }
+        if (files.length < 1){ notifications.error('En az 1 PDF yükleyin'); return; }
+        if (files.length > 10){ notifications.error('Maksimum 10 dosya'); return; }
         const btn = document.getElementById('processButton');
         if (btn) btn.disabled = true;
         try {
-            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: 'Dosya yükleniyor' });
-            const up = await pdfApi.uploadFileForRotate(files[0]);
+            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `${files.length} dosya yükleniyor` });
+            const up = await pdfApi.uploadFilesForRotate(files);
             const sessionId = up.session_id;
             const deg = parseInt(document.getElementById('rotateDirection')?.value || '90', 10);
             pdfLoader.updateProgress(50, 'PDF döndürülüyor...');
@@ -37,7 +35,7 @@ class RotateTool {
     showResult(result){
         const resultArea = document.getElementById('resultArea');
         if (!resultArea) return;
-        const url = pdfApi.getRotateDownloadUrl(result.session_id, result.output_file);
+        const url = window.location.origin + result.download_url;
         fileHandler.triggerFileDownload(url);
         const downloadBtn = resultArea.querySelector('button');
         if (downloadBtn){
@@ -61,7 +59,7 @@ class RotateTool {
     }
 
     getFunnyQuote(){ return 'Dünya ters dönerse, PDF de döner!'; }
-    getDescription(){ return 'PDF sayfalarını 90°/180°/270° açılarıyla döndürün.'; }
+    getDescription(){ return 'PDF sayfalarını 90°/180°/270° açılarıyla döndürün. Birden fazlaysa ZIP olarak indirin.'; }
 }
 
 const rotateTool = new RotateTool();

--- a/site/js/tools/watermark.js
+++ b/site/js/tools/watermark.js
@@ -11,7 +11,8 @@ class WatermarkTool {
 
     async process(){
         const files = fileHandler.getSelectedFiles();
-        if (files.length !== 1){ notifications.error('Lütfen tek bir PDF yükleyin'); return; }
+        if (files.length < 1){ notifications.error('En az 1 PDF yükleyin'); return; }
+        if (files.length > 10){ notifications.error('Maksimum 10 dosya'); return; }
         const text = document.getElementById('watermarkText')?.value || '';
         if (!text){ notifications.error('Filigran metni girin'); return; }
         const position = document.getElementById('watermarkPosition')?.value || 'center';
@@ -20,8 +21,8 @@ class WatermarkTool {
         const btn = document.getElementById('processButton');
         if (btn) btn.disabled = true;
         try {
-            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: 'Dosya yükleniyor' });
-            const up = await pdfApi.uploadFileForWatermark(files[0]);
+            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `${files.length} dosya yükleniyor` });
+            const up = await pdfApi.uploadFilesForWatermark(files);
             const sessionId = up.session_id;
             pdfLoader.updateProgress(50, 'Filigran uygulanıyor...');
             const result = await pdfApi.processWatermark(sessionId, { text, position, fontSize, color });
@@ -38,7 +39,7 @@ class WatermarkTool {
     showResult(result){
         const resultArea = document.getElementById('resultArea');
         if (!resultArea) return;
-        const url = pdfApi.getWatermarkDownloadUrl(result.session_id, result.output_file);
+        const url = window.location.origin + result.download_url;
         fileHandler.triggerFileDownload(url);
         const downloadBtn = resultArea.querySelector('button');
         if (downloadBtn){
@@ -75,7 +76,7 @@ class WatermarkTool {
     }
 
     getFunnyQuote(){ return 'İmzanız her sayfada!'; }
-    getDescription(){ return 'Metin filigranı ekleyin, konum ve stilini seçin.'; }
+    getDescription(){ return 'Metin filigranı ekleyin, konum ve stilini seçin. Birden fazlaysa ZIP olarak indirin.'; }
 }
 
 const watermarkTool = new WatermarkTool();


### PR DESCRIPTION
## Summary
- allow rotate, protect and watermark endpoints to accept multiple PDFs and zip results
- update frontend API and tools to upload multiple files and handle zip downloads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2a6c1c0a4832782dd9da6be427172