### PR TITLE
Add PDF organize tool with drag-and-drop page management

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from routers.unlock import router as unlock_router
 from routers.rotate import router as rotate_router
 from routers.watermark import router as watermark_router
 from routers.pdf_to_jpg import router as pdf_to_jpg_router
+from routers.organize import router as organize_router
 
 
 logging.basicConfig(level=logging.INFO)
@@ -86,4 +87,5 @@ app.include_router(unlock_router)
 app.include_router(rotate_router)
 app.include_router(watermark_router)
 app.include_router(pdf_to_jpg_router)
+app.include_router(organize_router)
 

--- a/app/organize.py
+++ b/app/organize.py
@@ -1,0 +1,78 @@
+"""
+PDF Düzenleme (Sayfa Sıralama/Silme) Modülü
+PDFişlemleri.com için PDF sayfalarını yeniden sıralama ve silme işlemlerini yönetir.
+"""
+
+import os
+import tempfile
+import logging
+from typing import List, Optional, Dict
+from PyPDF2 import PdfReader, PdfWriter
+
+logger = logging.getLogger(__name__)
+
+
+class PDFOrganizeError(Exception):
+    """PDF düzenleme işlemi sırasında oluşan hatalar için özel exception"""
+    pass
+
+
+class PDFOrganizer:
+    """PDF sayfalarını yeniden düzenleme işlemlerini yöneten sınıf"""
+
+    def __init__(self, temp_dir: Optional[str] = None):
+        self.temp_dir = temp_dir or tempfile.gettempdir()
+
+    def organize(self, pdf_files: List[str], page_order: List[Dict[str, int]], output_path: str) -> str:
+        """Belirtilen sayfa sırasına göre PDF oluşturur.
+
+        Args:
+            pdf_files: Yüklenmiş PDF dosyalarının yol listesi
+            page_order: {'file_index': int, 'page_number': int} içeren liste
+            output_path: Oluşturulacak PDF'in yolu
+        Returns:
+            Çıktı PDF dosya yolu
+        Raises:
+            PDFOrganizeError: Geçersiz sayfa veya dosya durumlarında
+        """
+        if not page_order:
+            raise PDFOrganizeError("Sayfa sırası boş")
+
+        writer = PdfWriter()
+        readers: Dict[int, PdfReader] = {}
+
+        try:
+            for item in page_order:
+                file_index = item.get("file_index")
+                page_number = item.get("page_number")
+
+                if file_index is None or page_number is None:
+                    raise PDFOrganizeError("Geçersiz sayfa bilgisi")
+
+                if file_index < 0 or file_index >= len(pdf_files):
+                    raise PDFOrganizeError(f"Geçersiz dosya indexi: {file_index}")
+
+                if file_index not in readers:
+                    readers[file_index] = PdfReader(pdf_files[file_index])
+
+                reader = readers[file_index]
+                if page_number < 1 or page_number > len(reader.pages):
+                    raise PDFOrganizeError(f"Geçersiz sayfa numarası: {page_number}")
+
+                writer.add_page(reader.pages[page_number - 1])
+
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+            with open(output_path, "wb") as f:
+                writer.write(f)
+
+            logger.info("PDF organize işlemi tamamlandı: %s", output_path)
+            return output_path
+        except Exception as e:
+            logger.error("PDF organize hatası: %s", e)
+            raise PDFOrganizeError(str(e))
+
+    def get_pdf_info(self, pdf_path: str) -> dict:
+        """PDF dosyası hakkında temel bilgi döndürür"""
+        reader = PdfReader(pdf_path)
+        file_size_mb = round(os.path.getsize(pdf_path) / (1024 * 1024), 2)
+        return {"page_count": len(reader.pages), "file_size_mb": file_size_mb}

--- a/app/routers/organize.py
+++ b/app/routers/organize.py
@@ -1,0 +1,196 @@
+import os
+import shutil
+from pathlib import Path
+from datetime import datetime, timedelta
+from typing import List
+import logging
+
+from fastapi import APIRouter, File, UploadFile, HTTPException, BackgroundTasks, Request
+from fastapi.responses import FileResponse, Response
+from pydantic import BaseModel
+
+from core.config import settings
+from core.utils import validate_pdf_file, save_upload_file, cleanup_old_files, ensure_safe_path
+from organize import PDFOrganizer, PDFOrganizeError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/tools/organize", tags=["organize"])
+
+
+class PageItem(BaseModel):
+    file_index: int
+    page_number: int
+
+
+class PageOrder(BaseModel):
+    pages: List[PageItem]
+
+
+@router.post("/upload")
+async def upload_pdfs_for_organize(
+    files: List[UploadFile] = File(...),
+    background_tasks: BackgroundTasks = BackgroundTasks(),
+):
+    if len(files) == 0:
+        raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
+    if len(files) > settings.MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"Maksimum {settings.MAX_FILES} dosya yüklenebilir")
+
+    session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
+    session_dir = os.path.join(settings.TEMP_DIR, session_id)
+    os.makedirs(session_dir, exist_ok=True)
+
+    uploaded_files = []
+    total_size = 0
+
+    try:
+        for idx, file in enumerate(files):
+            validate_pdf_file(file)
+            if getattr(file, "size", None) is not None:
+                total_size += file.size
+                if total_size > settings.MAX_FILE_SIZE:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Toplam dosya boyutu {settings.MAX_FILE_SIZE/(1024*1024)}MB sınırını aşıyor",
+                    )
+
+            file_path = Path(session_dir) / f"{idx}_{file.filename}"
+            await save_upload_file(file, file_path)
+
+            uploaded_files.append(
+                {
+                    "original_name": file.filename,
+                    "path": str(file_path),
+                    "size": getattr(file, "size", None) or 0,
+                }
+            )
+            logger.info(f"Dosya yüklendi: {file.filename}")
+
+        background_tasks.add_task(cleanup_old_files)
+
+        return {
+            "session_id": session_id,
+            "files": uploaded_files,
+            "total_files": len(uploaded_files),
+            "total_size_mb": round((total_size or 0) / (1024 * 1024), 2),
+        }
+    except Exception as e:
+        if os.path.exists(session_dir):
+            shutil.rmtree(session_dir)
+        if isinstance(e, HTTPException):
+            raise e
+        logger.error(f"Dosya yükleme hatası: {str(e)}")
+        raise HTTPException(status_code=500, detail="Dosya yükleme sırasında hata oluştu")
+
+
+@router.post("/process/{session_id}")
+async def process_organize(
+    session_id: str,
+    page_order: PageOrder,
+    background_tasks: BackgroundTasks = BackgroundTasks(),
+):
+    session_dir = os.path.join(settings.TEMP_DIR, session_id)
+    if not os.path.exists(session_dir):
+        raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
+
+    try:
+        files = [str(f) for f in Path(session_dir).glob("*.pdf")]
+        if not files:
+            raise HTTPException(status_code=400, detail="PDF dosyası bulunamadı")
+
+        def _upload_index_key(p: str) -> int:
+            name = Path(p).name
+            parts = name.split('_', 1)
+            if len(parts) == 2 and parts[0].isdigit():
+                return int(parts[0])
+            return 0
+
+        pdf_files = sorted(files, key=_upload_index_key)
+
+        if not page_order.pages:
+            raise HTTPException(status_code=400, detail="Sayfa sırası boş")
+
+        output_filename = f"organized_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pdf"
+        output_path = os.path.join(session_dir, output_filename)
+
+        organizer = PDFOrganizer(temp_dir=session_dir)
+        result_path = organizer.organize(
+            pdf_files=pdf_files,
+            page_order=[p.dict() for p in page_order.pages],
+            output_path=output_path,
+        )
+
+        file_info = organizer.get_pdf_info(result_path)
+        logger.info(f"PDF organize başarılı: {session_id}")
+
+        return {
+            "success": True,
+            "session_id": session_id,
+            "output_file": output_filename,
+            "file_info": file_info,
+            "download_url": f"/api/tools/organize/download/{session_id}/{output_filename}",
+        }
+    except PDFOrganizeError as e:
+        logger.error(f"PDF organize hatası: {str(e)}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"İşlem hatası: {str(e)}")
+        raise HTTPException(status_code=500, detail="PDF düzenleme sırasında hata oluştu")
+
+
+@router.api_route("/download/{session_id}/{filename}", methods=["GET", "HEAD"])
+async def download_organized_pdf(session_id: str, filename: str, request: Request):
+    session_dir = os.path.join(settings.TEMP_DIR, session_id)
+    file_path = os.path.join(session_dir, filename)
+
+    if not os.path.exists(session_dir):
+        logger.warning(f"Session bulunamadı: {session_id}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"İndirme oturumu bulunamadı veya süresi dolmuş ({settings.SESSION_LIFETIME_MINUTES} dakika). Dosyaları tekrar yükleyip işleyin.",
+        )
+
+    if not os.path.exists(file_path) or not filename.endswith(".pdf"):
+        logger.warning(f"Dosya bulunamadı: {file_path}")
+        raise HTTPException(status_code=404, detail="Dosya bulunamadı veya silinmiş")
+
+    ensure_safe_path(file_path, settings.TEMP_DIR)
+
+    try:
+        session_time = datetime.fromtimestamp(os.path.getctime(session_dir))
+        if datetime.now() - session_time > timedelta(minutes=settings.SESSION_LIFETIME_MINUTES):
+            logger.info(f"Session süresi dolmuş: {session_id}")
+            raise HTTPException(
+                status_code=410,
+                detail=f"İndirme linki süresi dolmuş ({settings.SESSION_LIFETIME_MINUTES} dakika). Lütfen dosyaları tekrar işleyin ve daha hızlı indirin.",
+            )
+    except Exception as e:
+        logger.error(f"Session time check failed: {e}")
+
+    if request.method == "HEAD":
+        logger.info(f"HEAD request: {filename} (Session: {session_id})")
+        return Response(
+            status_code=200,
+            headers={
+                "Content-Type": "application/pdf",
+                "Content-Length": str(os.path.getsize(file_path)),
+                "Content-Disposition": f"attachment; filename={filename}",
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                "Pragma": "no-cache",
+                "Expires": "0",
+            },
+        )
+
+    logger.info(f"Dosya indiriliyor: {filename} (Session: {session_id})")
+    return FileResponse(
+        path=file_path,
+        media_type="application/pdf",
+        filename=filename,
+        headers={
+            "Content-Disposition": f"attachment; filename={filename}",
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Pragma": "no-cache",
+            "Expires": "0",
+        },
+    )

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -9,6 +9,7 @@ import pdfLoader from './modules/loader.js';
 import fileHandler from './modules/fileHandler.js';
 import toolManager from './modules/toolManager.js';
 import mergeTool from './tools/merge.js';
+import organizeTool from './tools/organize.js';
 import { ThemeManager } from './theme-manager.js';
 
 // Global API instance'larını window'a ekle
@@ -18,6 +19,7 @@ window.pdfLoader = pdfLoader;
 window.fileHandler = fileHandler;
 window.toolManager = toolManager;
 window.mergeTool = mergeTool;
+window.organizeTool = organizeTool;
 
 // Tema yönetimi import edildi
 

--- a/site/js/modules/api.js
+++ b/site/js/modules/api.js
@@ -120,6 +120,35 @@ class PDFApi {
         return `${this.baseUrl}/tools/merge/download/${sessionId}/${filename}`;
     }
 
+    // ===== Organize APIs =====
+    async uploadFilesForOrganize(files) {
+        const formData = new FormData();
+        files.forEach(f => formData.append('files', f));
+        const res = await fetch(`${this.baseUrl}/tools/organize/upload`, { method: 'POST', body: formData });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.detail || 'Dosya yükleme hatası');
+        }
+        return res.json();
+    }
+
+    async processOrganize(sessionId, pageOrder) {
+        const res = await fetch(`${this.baseUrl}/tools/organize/process/${sessionId}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pages: pageOrder })
+        });
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.detail || 'Organize işlem hatası');
+        }
+        return res.json();
+    }
+
+    getOrganizeDownloadUrl(sessionId, filename) {
+        return `${this.baseUrl}/tools/organize/download/${sessionId}/${filename}`;
+    }
+
     // ===== Split APIs =====
     async uploadFileForSplit(file) {
         const formData = new FormData();

--- a/site/js/modules/fileHandler.js
+++ b/site/js/modules/fileHandler.js
@@ -207,7 +207,7 @@ class FileHandler {
             <span>${totalSizeMB}MB / 50MB</span>
         `;
         filesList.appendChild(limitInfo);
-        
+
         const selectedFilesElement = document.getElementById('selectedFiles');
         if (selectedFilesElement) {
             selectedFilesElement.classList.remove('hidden');
@@ -234,6 +234,9 @@ class FileHandler {
                 }
             }, 100);
         }
+
+        // Custom event: notify listeners that files list updated
+        document.dispatchEvent(new CustomEvent('filesUpdated', { detail: { files: this.selectedFiles } }));
     }
 
     /**

--- a/site/js/modules/toolManager.js
+++ b/site/js/modules/toolManager.js
@@ -14,6 +14,7 @@ import unlockTool from '../tools/unlock.js';
 import rotateTool from '../tools/rotate.js';
 import watermarkTool from '../tools/watermark.js';
 import pdfToJpgTool from '../tools/pdf-to-jpg.js';
+import organizeTool from '../tools/organize.js';
 import notifications from './notifications.js';
 import fileHandler from './fileHandler.js';
 import pdfLoader from './loader.js';
@@ -32,7 +33,8 @@ class ToolManager {
             'unlock': unlockTool,
             'rotate': rotateTool,
             'watermark': watermarkTool,
-            'pdf-to-jpg': pdfToJpgTool
+            'pdf-to-jpg': pdfToJpgTool,
+            'organize': organizeTool
         };
         
         this.initializeEventListeners();

--- a/site/js/tools/organize.js
+++ b/site/js/tools/organize.js
@@ -1,0 +1,159 @@
+import pdfApi from '../modules/api.js';
+import notifications from '../modules/notifications.js';
+import pdfLoader from '../modules/loader.js';
+import fileHandler from '../modules/fileHandler.js';
+
+// PDF.js CDN import will be done dynamically
+let pdfjsLib = null;
+
+class OrganizeTool {
+    constructor() {
+        this.toolId = 'organize';
+        this.toolName = 'PDF Düzenle';
+        this.pageOrder = [];
+    }
+
+    mount() {
+        document.addEventListener('filesUpdated', (e) => this.renderPreviews(e.detail.files));
+        // İlk yüklenen dosyalar varsa render et
+        this.renderPreviews(fileHandler.getSelectedFiles());
+    }
+
+    async ensurePdfJs() {
+        if (!pdfjsLib) {
+            try {
+                pdfjsLib = await import('https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.min.mjs');
+            } catch (err) {
+                notifications.error('PDF önizleme için gerekli kütüphane yüklenemedi');
+                throw err;
+            }
+        }
+    }
+
+    async renderPreviews(files) {
+        const container = document.getElementById('organizePreview');
+        if (!container) return;
+        container.innerHTML = '';
+        this.pageOrder = [];
+        if (!files || files.length === 0) return;
+
+        await this.ensurePdfJs();
+
+        for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+            const file = files[fileIndex];
+            try {
+                const arrayBuffer = await file.arrayBuffer();
+                const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+                for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+                    const page = await pdf.getPage(pageNum);
+                    const viewport = page.getViewport({ scale: 0.2 });
+                    const canvas = document.createElement('canvas');
+                    canvas.width = viewport.width;
+                    canvas.height = viewport.height;
+                    await page.render({ canvasContext: canvas.getContext('2d'), viewport }).promise;
+
+                    const wrapper = document.createElement('div');
+                    wrapper.className = 'page-thumb';
+                    wrapper.draggable = true;
+                    wrapper.dataset.fileIndex = String(fileIndex);
+                    wrapper.dataset.pageNumber = String(pageNum);
+                    wrapper.appendChild(canvas);
+
+                    const del = document.createElement('button');
+                    del.className = 'delete-page';
+                    del.innerHTML = '&times;';
+                    del.onclick = () => { wrapper.remove(); this.updatePageOrder(); };
+                    wrapper.appendChild(del);
+
+                    container.appendChild(wrapper);
+                }
+            } catch (err) {
+                console.error('Preview oluşturma hatası', err);
+            }
+        }
+        this.enableDragSort(container);
+        this.updatePageOrder();
+    }
+
+    enableDragSort(container) {
+        let dragging = null;
+        container.querySelectorAll('.page-thumb').forEach((el) => {
+            el.addEventListener('dragstart', (e) => {
+                dragging = el;
+                el.classList.add('dragging');
+            });
+            el.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                const target = e.currentTarget;
+                if (!dragging || target === dragging) return;
+                const rect = target.getBoundingClientRect();
+                const next = (e.clientY - rect.top) > rect.height / 2;
+                container.insertBefore(dragging, next ? target.nextSibling : target);
+            });
+            el.addEventListener('dragend', () => {
+                if (dragging) dragging.classList.remove('dragging');
+                dragging = null;
+                this.updatePageOrder();
+            });
+        });
+    }
+
+    updatePageOrder() {
+        const container = document.getElementById('organizePreview');
+        if (!container) return;
+        this.pageOrder = Array.from(container.querySelectorAll('.page-thumb')).map(el => ({
+            file_index: Number(el.dataset.fileIndex),
+            page_number: Number(el.dataset.pageNumber)
+        }));
+    }
+
+    async process() {
+        const files = fileHandler.getSelectedFiles();
+        if (files.length === 0) { notifications.error('Lütfen PDF dosyaları ekleyin'); return; }
+        if (!this.pageOrder.length) { notifications.error('Hiç sayfa seçilmedi'); return; }
+
+        const processButton = document.getElementById('processButton');
+        if (processButton) processButton.disabled = true;
+
+        try {
+            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `${files.length} dosya yükleniyor` });
+            pdfLoader.updateProgress(10, 'Dosyalar sunucuya yükleniyor...');
+            const uploadRes = await pdfApi.uploadFilesForOrganize(files);
+            const sessionId = uploadRes.session_id;
+            pdfLoader.updateProgress(50, 'Sayfalar düzenleniyor...');
+            const result = await pdfApi.processOrganize(sessionId, this.pageOrder);
+            pdfLoader.updateProgress(100, 'Tamamlandı!');
+            setTimeout(() => { pdfLoader.hide(); this.showResult(result); }, 150);
+        } catch (err) {
+            console.error('Organize process failed', err);
+            pdfLoader.hide();
+            notifications.error(err.message || 'İşlem sırasında hata oluştu');
+            if (processButton) processButton.disabled = false;
+        }
+    }
+
+    showResult(result) {
+        const resultArea = document.getElementById('resultArea');
+        if (!resultArea) return;
+        const url = pdfApi.getOrganizeDownloadUrl(result.session_id, result.output_file);
+        fileHandler.triggerFileDownload(url);
+        const downloadBtn = resultArea.querySelector('button');
+        if (downloadBtn) {
+            downloadBtn.innerHTML = '<i class="fas fa-download mr-2"></i>Tekrar İndir';
+            downloadBtn.onclick = () => fileHandler.triggerFileDownload(url);
+        }
+        resultArea.classList.remove('hidden');
+        notifications.success('PDF başarıyla düzenlendi!');
+    }
+
+    getOptions() {
+        return '<div id="organizePreview" class="organize-preview"></div>';
+    }
+
+    getFunnyQuote() { return 'Sayfalarınızı tokat gibi hizaya getirin!'; }
+
+    getDescription() { return 'PDF sayfalarını sürükle-bırak ile yeniden sıralayın veya silin.'; }
+}
+
+const organizeTool = new OrganizeTool();
+export default organizeTool;

--- a/site/style.css
+++ b/site/style.css
@@ -968,6 +968,52 @@ textarea:focus {
     color: #ef4444;
 }
 
+/* Organize tool page previews */
+.organize-preview {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.page-thumb {
+    position: relative;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.25rem;
+    overflow: hidden;
+    background: #fff;
+    width: 120px;
+}
+
+.page-thumb canvas {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.page-thumb.dragging {
+    opacity: 0.6;
+}
+
+.delete-page {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: rgba(0,0,0,0.5);
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.delete-page:hover {
+    background: rgba(239,68,68,0.8);
+}
+
 /* Modal styles */
 .modal {
     position: fixed;


### PR DESCRIPTION
## Summary
- Implement `PDFOrganizer` module and router to reorder or remove pages from multiple PDFs
- Integrate new organize tool on frontend with PDF.js previews, drag-and-drop sorting, and deletion controls
- Dispatch file update events and add styles and API methods for organize operations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2cbd5d6b08327b42ac1b8b74ba28f