### PR TITLE
refactor caddyfile for domain-based config

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,9 +1,8 @@
 {
   email {env.EMAIL}
-  auto_https
 }
 
-:80 {
+pdfislemleri.com {
   encode zstd gzip
   
   # Ana site root


### PR DESCRIPTION
## Summary
- remove explicit auto_https directive
- use pdfislemleri.com as site block instead of :80

## Testing
- `docker compose ps` *(fails: command not found: docker)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f8f4b3f08327a704aaaf7129ba37