### PR TITLE
Fix insecure merge logging

### DIFF
--- a/app/merge.py
+++ b/app/merge.py
@@ -11,6 +11,8 @@ import logging
 from PyPDF2 import PdfMerger, PdfReader
 from datetime import datetime
 
+from core.utils import sanitize_error_message
+
 # Logger ayarla
 logger = logging.getLogger(__name__)
 
@@ -48,7 +50,7 @@ class PDFMerger:
                 PdfReader(file)
             return True
         except Exception as e:
-            logger.error(f"PDF doğrulama hatası: {str(e)}")
+            logger.error(f"PDF doğrulama hatası: {sanitize_error_message(e, 'Doğrulama')}")
             return False
     
     def merge_pdfs(self, 
@@ -86,22 +88,15 @@ class PDFMerger:
             pdf_files = sorted(pdf_files, key=_alpha_key)
         
         # Tüm dosyaları doğrula
-        invalid_files = []
         for pdf_file in pdf_files:
-            if not os.path.exists(pdf_file):
-                invalid_files.append(f"{pdf_file} (dosya bulunamadı)")
-            elif not self.validate_pdf(pdf_file):
-                invalid_files.append(f"{pdf_file} (geçersiz PDF)")
-        
-        if invalid_files:
-            raise PDFMergeError(f"Geçersiz dosyalar: {', '.join(invalid_files)}")
+            if not os.path.exists(pdf_file) or not self.validate_pdf(pdf_file):
+                raise PDFMergeError("Geçersiz PDF dosyası")
         
         # Birleştirme işlemi
         try:
             self.merger = PdfMerger()
             
             for pdf_file in pdf_files:
-                logger.info(f"Ekleniyor: {pdf_file}")
                 self.merger.append(pdf_file)
             
             # Çıktı dizinini oluştur
@@ -113,12 +108,12 @@ class PDFMerger:
             with open(output_path, 'wb') as output_file:
                 self.merger.write(output_file)
             
-            logger.info(f"PDF birleştirme başarılı: {output_path}")
+            logger.info("PDF birleştirme başarılı")
             return output_path
-            
+
         except Exception as e:
-            logger.error(f"PDF birleştirme hatası: {str(e)}")
-            raise PDFMergeError(f"Birleştirme işlemi başarısız: {str(e)}")
+            logger.error(f"PDF birleştirme hatası: {sanitize_error_message(e, 'Birleştirme')}")
+            raise PDFMergeError("Birleştirme işlemi başarısız")
         finally:
             if self.merger:
                 self.merger.close()
@@ -148,7 +143,7 @@ class PDFMerger:
                 pages = config.get('pages', None)
                 
                 if not pdf_path or not os.path.exists(pdf_path):
-                    raise PDFMergeError(f"Geçersiz dosya yolu: {pdf_path}")
+                    raise PDFMergeError("Geçersiz dosya yolu")
                 
                 if pages:
                     # Sayfa aralıklarını parse et
@@ -166,8 +161,8 @@ class PDFMerger:
             return output_path
             
         except Exception as e:
-            logger.error(f"Sayfa aralıklı birleştirme hatası: {str(e)}")
-            raise PDFMergeError(f"İşlem başarısız: {str(e)}")
+            logger.error(f"Sayfa aralıklı birleştirme hatası: {sanitize_error_message(e, 'Birleştirme')}")
+            raise PDFMergeError("İşlem başarısız")
         finally:
             if self.merger:
                 self.merger.close()
@@ -206,13 +201,12 @@ class PDFMerger:
             with open(pdf_path, 'rb') as file:
                 reader = PdfReader(file)
                 page_count = len(reader.pages)
-                
+
                 # Metadata bilgileri
                 metadata = reader.metadata if reader.metadata else {}
-                
+
                 return {
                     'file_name': os.path.basename(pdf_path),
-                    'file_path': pdf_path,
                     'page_count': page_count,
                     'file_size_mb': round(file_size, 2),
                     'title': metadata.get('/Title', ''),
@@ -220,9 +214,9 @@ class PDFMerger:
                     'creation_date': metadata.get('/CreationDate', ''),
                     'is_encrypted': reader.is_encrypted
                 }
-                
+
         except Exception as e:
-            logger.error(f"PDF bilgi alma hatası: {str(e)}")
+            logger.error(f"PDF bilgi alma hatası: {sanitize_error_message(e, 'Bilgi alma')}")
             return None
     
     def create_temp_file(self, prefix: str = "merged_", suffix: str = ".pdf") -> str:

--- a/app/routers/merge.py
+++ b/app/routers/merge.py
@@ -9,7 +9,14 @@ from fastapi import APIRouter, File, UploadFile, HTTPException, BackgroundTasks,
 from fastapi.responses import FileResponse, Response
 
 from core.config import settings
-from core.utils import validate_pdf_file, save_upload_file, cleanup_old_files, ensure_safe_path, sanitize_error_message, log_operation_safely
+from core.utils import (
+    validate_pdf_file,
+    save_upload_file,
+    cleanup_old_files,
+    ensure_safe_path,
+    sanitize_error_message,
+    log_operation_safely,
+)
 from merge import PDFMerger, PDFMergeError
 
 
@@ -71,8 +78,9 @@ async def upload_pdfs_for_merge(
             shutil.rmtree(session_dir)
         if isinstance(e, HTTPException):
             raise e
-        logger.error(f"Dosya yükleme hatası: {str(e)}")
-        raise HTTPException(status_code=500, detail="Dosya yükleme sırasında hata oluştu")
+        msg = sanitize_error_message(e, "Yükleme")
+        logger.error(f"Dosya yükleme hatası: {msg}")
+        raise HTTPException(status_code=500, detail=msg)
 
 
 @router.post("/process/{session_id}")
@@ -122,11 +130,13 @@ async def process_merge(
             "download_url": f"/api/tools/merge/download/{session_id}/{output_filename}",
         }
     except PDFMergeError as e:
-        logger.error(f"PDF birleştirme hatası: {str(e)}")
-        raise HTTPException(status_code=400, detail=str(e))
+        msg = sanitize_error_message(e, "Birleştirme")
+        logger.error(f"PDF birleştirme hatası: {msg}")
+        raise HTTPException(status_code=400, detail=msg)
     except Exception as e:
-        logger.error(f"İşlem hatası: {str(e)}")
-        raise HTTPException(status_code=500, detail="PDF birleştirme sırasında hata oluştu")
+        msg = sanitize_error_message(e, "Birleştirme")
+        logger.error(f"İşlem hatası: {msg}")
+        raise HTTPException(status_code=500, detail=msg)
 
 
 @router.api_route("/download/{session_id}/{filename}", methods=["GET", "HEAD"])
@@ -142,7 +152,7 @@ async def download_merged_pdf(session_id: str, filename: str, request: Request):
         )
 
     if not os.path.exists(file_path) or not filename.endswith('.pdf'):
-        logger.warning(f"Dosya bulunamadı: {file_path}")
+        logger.warning(f"Dosya bulunamadı. Session: {session_id}")
         raise HTTPException(status_code=404, detail="Dosya bulunamadı veya silinmiş")
 
     ensure_safe_path(file_path, settings.TEMP_DIR)
@@ -156,7 +166,7 @@ async def download_merged_pdf(session_id: str, filename: str, request: Request):
                 detail=f"İndirme linki süresi dolmuş ({settings.SESSION_LIFETIME_MINUTES} dakika). Lütfen dosyaları tekrar işleyin ve daha hızlı indirin.",
             )
     except Exception as e:
-        logger.error(f"Session time check failed: {e}")
+        logger.error(f"Session time check failed: {sanitize_error_message(e, 'Session kontrol')}")
 
     if request.method == "HEAD":
         log_operation_safely("head_request", session_id, 1)
@@ -172,7 +182,7 @@ async def download_merged_pdf(session_id: str, filename: str, request: Request):
             },
         )
 
-            log_operation_safely("file_download", session_id, 1)
+    log_operation_safely("file_download", session_id, 1)
     return FileResponse(
         path=file_path,
         media_type="application/pdf",


### PR DESCRIPTION
## Summary
- sanitize merge router errors and avoid leaking file paths
- remove file path logs from core merger and sanitize error messages
- ensure downloads are logged via `log_operation_safely`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b42b0c5b78832786c7b40b9ae89656