### PR TITLE
fix: remove tailwind CDN script and handle API health check gracefully

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -40,7 +40,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/blog.html
+++ b/site/blog.html
@@ -40,7 +40,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/blog/pdf-birlestirme.html
+++ b/site/blog/pdf-birlestirme.html
@@ -40,7 +40,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/blog/pdf-boyut-kucultme.html
+++ b/site/blog/pdf-boyut-kucultme.html
@@ -40,7 +40,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/blog/pdf-formlari.html
+++ b/site/blog/pdf-formlari.html
@@ -40,7 +40,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/blog/pdf-guvenlik.html
+++ b/site/blog/pdf-guvenlik.html
@@ -40,7 +40,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/blog/pdf-imzalama.html
+++ b/site/blog/pdf-imzalama.html
@@ -40,7 +40,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/blog/pdf-ocr.html
+++ b/site/blog/pdf-ocr.html
@@ -40,7 +40,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/blog/telefondan-pdf-duzenleme.html
+++ b/site/blog/telefondan-pdf-duzenleme.html
@@ -40,7 +40,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/blog/word-pdf-donusturme.html
+++ b/site/blog/word-pdf-donusturme.html
@@ -40,7 +40,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/contact.html
+++ b/site/contact.html
@@ -28,7 +28,8 @@
             <link rel="manifest" href="/icons/site.webmanifest">
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     
     <!-- Custom CSS -->
     <link rel="stylesheet" href="style.css">

--- a/site/cookies.html
+++ b/site/cookies.html
@@ -28,7 +28,8 @@
             <link rel="manifest" href="/icons/site.webmanifest">
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     
     <!-- Custom CSS -->
     <link rel="stylesheet" href="style.css">

--- a/site/index.html
+++ b/site/index.html
@@ -53,15 +53,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script>
-        // Production uyarısını gizle
-        tailwind.config = {
-            corePlugins: {
-                preflight: false,
-            }
-        }
-    </script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
     <!-- Custom CSS -->

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -207,12 +207,11 @@ class App {
             initializeButtonEventListeners();
             
             // API health check
-            try {
-                const health = await pdfApi.checkHealth();
+            const health = await pdfApi.checkHealth();
+            if (health) {
                 console.log('API Status:', health);
-            } catch (error) {
-                console.warn('API not available:', error);
-                notifications.info('Bazı özellikler çevrimdışı olabilir');
+            } else {
+                console.warn('API not available');
             }
             
             console.log('PDFişlemleri.com loaded! 🎉');

--- a/site/js/modules/api.js
+++ b/site/js/modules/api.js
@@ -22,11 +22,20 @@ class PDFApi {
      */
     async checkHealth() {
         try {
-            const response = await fetch(`${this.baseUrl}/status`);
+            const response = await fetch(`${this.baseUrl}/status`, {
+                headers: {
+                    'Accept': 'application/json'
+                }
+            });
+            const contentType = response.headers.get('content-type') || '';
+            if (!response.ok || !contentType.includes('application/json')) {
+                console.warn('Unexpected API health response:', response.status, contentType);
+                return null;
+            }
             return await response.json();
         } catch (error) {
             console.error('API health check failed:', error);
-            throw error;
+            return null;
         }
     }
 

--- a/site/kvkk.html
+++ b/site/kvkk.html
@@ -28,7 +28,8 @@
             <link rel="manifest" href="/icons/site.webmanifest">
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     
     <!-- Custom CSS -->
     <link rel="stylesheet" href="style.css">

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -24,7 +24,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->

--- a/site/terms.html
+++ b/site/terms.html
@@ -33,7 +33,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     
     <!-- Custom CSS -->


### PR DESCRIPTION
## Summary
- replace Tailwind CDN script with compiled CSS link across static pages
- handle API health check errors without user-facing notifications

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b44c301ab483278523b9a5deedc7e1