### PR TITLE
Enable multi-file conversions and improve tool switching

### DIFF
--- a/app/routers/pdf_to_jpg.py
+++ b/app/routers/pdf_to_jpg.py
@@ -15,16 +15,27 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/tools/pdf-to-jpg", tags=["pdf-to-jpg"])
 
+
 @router.post("/upload")
-async def upload_pdf_for_jpg(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdf_for_jpg(files: list[UploadFile] = File(...)):
+    if not files:
+        raise HTTPException(status_code=400, detail="Dosya yüklenmedi")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
+    saved = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for file in files:
+            validate_pdf_file(file)
+            file_path = Path(session_dir) / file.filename
+            await save_upload_file(file, file_path)
+            saved.append({
+                "original_name": file.filename,
+                "path": str(file_path),
+                "size": getattr(file, "size", 0),
+            })
+        return {"session_id": session_id, "files": saved}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -32,31 +43,40 @@ async def upload_pdf_for_jpg(file: UploadFile = File(...)):
         logger.error(f"PDF→JPG upload failed: {e}")
         raise HTTPException(status_code=500, detail="Dosya yükleme sırasında hata oluştu")
 
+
 @router.post("/process/{session_id}")
 async def process_pdf_to_jpg(session_id: str, dpi: int = 200):
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     if not os.path.exists(session_dir):
         raise HTTPException(status_code=404, detail="Oturum bulunamadı veya süresi dolmuş")
+
     pdf_files = list(Path(session_dir).glob("*.pdf"))
     if not pdf_files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdf_files[0])
+
     converter = PDFToJPGConverter(temp_dir=session_dir)
-    images = converter.convert(input_pdf, session_dir, dpi)
-    if len(images) > 1:
-        zip_name = f"images_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
-        zip_path = os.path.join(session_dir, zip_name)
-        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
-            for img in images:
-                zf.write(img, arcname=os.path.basename(img))
-        output_file = zip_name
-    else:
-        output_file = os.path.basename(images[0])
+    all_images = []
+    for pdf in pdf_files:
+        sub_dir = os.path.join(session_dir, Path(pdf).stem)
+        os.makedirs(sub_dir, exist_ok=True)
+        images = converter.convert(str(pdf), sub_dir, dpi)
+        for img in images:
+            all_images.append((img, os.path.join(Path(pdf).stem, os.path.basename(img))))
+
+    if not all_images:
+        raise HTTPException(status_code=500, detail="Görsel oluşturulamadı")
+
+    zip_name = f"images_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+    zip_path = os.path.join(session_dir, zip_name)
+    with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for img_path, arc in all_images:
+            zf.write(img_path, arcname=arc)
+
     return {
         "success": True,
         "session_id": session_id,
-        "output_file": output_file,
-        "download_url": f"/api/tools/pdf-to-jpg/download/{session_id}/{output_file}",
+        "output_file": zip_name,
+        "download_url": f"/api/tools/pdf-to-jpg/download/{session_id}/{zip_name}",
     }
 
 @router.get("/download/{session_id}/{filename}")

--- a/app/routers/pdf_to_ppt.py
+++ b/app/routers/pdf_to_ppt.py
@@ -1,7 +1,8 @@
 import os
-from pathlib import Path
-from datetime import datetime
 import logging
+import zipfile
+from datetime import datetime
+from pathlib import Path
 
 from fastapi import APIRouter, File, UploadFile, HTTPException
 from fastapi.responses import FileResponse
@@ -18,16 +19,26 @@ router = APIRouter(prefix="/api/tools/pdf-to-ppt", tags=["pdf-to-ppt"])
 
 
 @router.post("/upload")
-async def upload_pdf_for_ppt(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdf_for_ppt(files: list[UploadFile] = File(...)):
+    if not files:
+        raise HTTPException(status_code=400, detail="Dosya yüklenmedi")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    saved = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for file in files:
+            validate_pdf_file(file)
+            file_path = Path(session_dir) / file.filename
+            await save_upload_file(file, file_path)
+            saved.append({
+                "original_name": file.filename,
+                "path": str(file_path),
+                "size": getattr(file, "size", 0),
+            })
+        return {"session_id": session_id, "files": saved}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -45,24 +56,35 @@ async def process_pdf_to_ppt(session_id: str):
     pdfs = list(Path(session_dir).glob("*.pdf"))
     if not pdfs:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdfs[0])
 
     converter = PDFToPPTConverter(temp_dir=session_dir)
-    try:
-        result = converter.convert(input_pdf)
-        output_name = os.path.basename(result.output_path)
-        return {
-            "success": True,
-            "session_id": session_id,
-            "output_file": output_name,
-            "page_count": result.page_count,
-            "download_url": f"/api/tools/pdf-to-ppt/download/{session_id}/{output_name}",
-        }
-    except PDFToPPTError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"PDF→PPT process error: {e}")
-        raise HTTPException(status_code=500, detail="Dönüştürme sırasında hata oluştu")
+    outputs = []
+    for pdf in pdfs:
+        try:
+            result = converter.convert(str(pdf))
+            outputs.append(result.output_path)
+        except PDFToPPTError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            logger.error(f"PDF→PPT process error: {e}")
+            raise HTTPException(status_code=500, detail="Dönüştürme sırasında hata oluştu")
+
+    if len(outputs) == 1:
+        output_name = os.path.basename(outputs[0])
+    else:
+        zip_name = f"pdf_to_ppt_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for out in outputs:
+                zf.write(out, arcname=os.path.basename(out))
+        output_name = zip_name
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "output_file": output_name,
+        "download_url": f"/api/tools/pdf-to-ppt/download/{session_id}/{output_name}",
+    }
 
 
 @router.get("/download/{session_id}/{filename}")
@@ -71,7 +93,7 @@ async def download_ppt(session_id: str, filename: str):
     file_path = os.path.join(session_dir, filename)
     if not os.path.exists(file_path):
         raise HTTPException(status_code=404, detail="Dosya bulunamadı")
-    media = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    media = "application/zip" if filename.lower().endswith('.zip') else "application/vnd.openxmlformats-officedocument.presentationml.presentation"
     return FileResponse(path=file_path, media_type=media, filename=filename)
 
 

--- a/app/routers/pdf_to_word.py
+++ b/app/routers/pdf_to_word.py
@@ -1,7 +1,8 @@
 import os
-from pathlib import Path
-from datetime import datetime
 import logging
+import zipfile
+from datetime import datetime
+from pathlib import Path
 
 from fastapi import APIRouter, File, UploadFile, HTTPException
 from fastapi.responses import FileResponse
@@ -18,16 +19,26 @@ router = APIRouter(prefix="/api/tools/pdf-to-word", tags=["pdf-to-word"])
 
 
 @router.post("/upload")
-async def upload_pdf_for_convert(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdf_for_convert(files: list[UploadFile] = File(...)):
+    if not files:
+        raise HTTPException(status_code=400, detail="Dosya yüklenmedi")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    saved_files = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for file in files:
+            validate_pdf_file(file)
+            file_path = Path(session_dir) / file.filename
+            await save_upload_file(file, file_path)
+            saved_files.append({
+                "original_name": file.filename,
+                "path": str(file_path),
+                "size": getattr(file, "size", 0),
+            })
+        return {"session_id": session_id, "files": saved_files}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -45,23 +56,35 @@ async def process_pdf_to_word(session_id: str):
     pdf_files = list(Path(session_dir).glob("*.pdf"))
     if not pdf_files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdf_files[0])
 
     converter = PDFToWordConverter(temp_dir=session_dir)
-    try:
-        result = converter.convert(input_pdf)
-        output_name = os.path.basename(result.output_path)
-        return {
-            "success": True,
-            "session_id": session_id,
-            "output_file": output_name,
-            "download_url": f"/api/tools/pdf-to-word/download/{session_id}/{output_name}",
-        }
-    except PDFToWordError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"PDF→Word process error: {e}")
-        raise HTTPException(status_code=500, detail="Dönüştürme sırasında hata oluştu")
+    outputs = []
+    for pdf in pdf_files:
+        try:
+            result = converter.convert(str(pdf))
+            outputs.append(result.output_path)
+        except PDFToWordError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            logger.error(f"PDF→Word process error: {e}")
+            raise HTTPException(status_code=500, detail="Dönüştürme sırasında hata oluştu")
+
+    if len(outputs) == 1:
+        output_name = os.path.basename(outputs[0])
+    else:
+        zip_name = f"pdf_to_word_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for out in outputs:
+                zf.write(out, arcname=os.path.basename(out))
+        output_name = zip_name
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "output_file": output_name,
+        "download_url": f"/api/tools/pdf-to-word/download/{session_id}/{output_name}",
+    }
 
 
 @router.get("/download/{session_id}/{filename}")
@@ -70,7 +93,7 @@ async def download_converted(session_id: str, filename: str):
     file_path = os.path.join(session_dir, filename)
     if not os.path.exists(file_path):
         raise HTTPException(status_code=404, detail="Dosya bulunamadı")
-    media = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    media = "application/zip" if filename.lower().endswith('.zip') else "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     return FileResponse(path=file_path, media_type=media, filename=filename)
 
 

--- a/app/routers/split.py
+++ b/app/routers/split.py
@@ -1,8 +1,9 @@
 import os
 import shutil
-from pathlib import Path
-from datetime import datetime
 import logging
+import zipfile
+from datetime import datetime
+from pathlib import Path
 
 from fastapi import APIRouter, File, UploadFile, HTTPException
 from fastapi.responses import FileResponse
@@ -19,19 +20,26 @@ router = APIRouter(prefix="/api/tools/split", tags=["split"])
 
 
 @router.post("/upload")
-async def upload_pdf_for_split(file: UploadFile = File(...)):
-    validate_pdf_file(file)
+async def upload_pdf_for_split(files: list[UploadFile] = File(...)):
+    if not files:
+        raise HTTPException(status_code=400, detail="Dosya yüklenmedi")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    saved = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {
-            "session_id": session_id,
-            "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)},
-        }
+        for file in files:
+            validate_pdf_file(file)
+            file_path = Path(session_dir) / file.filename
+            await save_upload_file(file, file_path)
+            saved.append({
+                "original_name": file.filename,
+                "path": str(file_path),
+                "size": getattr(file, "size", 0),
+            })
+        return {"session_id": session_id, "files": saved}
     except Exception as e:
         if os.path.exists(session_dir):
             shutil.rmtree(session_dir)
@@ -53,36 +61,46 @@ async def process_split(
     pdf_files = list(Path(session_dir).glob("*.pdf"))
     if not pdf_files:
         raise HTTPException(status_code=400, detail="PDF bulunamadı")
-    input_pdf = str(pdf_files[0])
 
     splitter = PDFSplitter(temp_dir=session_dir)
-    try:
-        if mode == "ranges":
-            if not pages:
-                raise HTTPException(status_code=400, detail="Sayfa aralıkları boş olamaz")
-            result = splitter.split_by_ranges(input_pdf, pages)
-        elif mode == "every_n":
-            if not every_n:
-                raise HTTPException(status_code=400, detail="Aralık değeri gerekli")
-            result = splitter.split_every_n(input_pdf, int(every_n))
-        else:
-            raise HTTPException(status_code=400, detail="Geçersiz mod")
+    all_outputs: list[str] = []
+    for pdf in pdf_files:
+        try:
+            if mode == "ranges":
+                if not pages:
+                    raise HTTPException(status_code=400, detail="Sayfa aralıkları boş olamaz")
+                result = splitter.split_by_ranges(str(pdf), pages)
+            elif mode == "every_n":
+                if not every_n:
+                    raise HTTPException(status_code=400, detail="Aralık değeri gerekli")
+                result = splitter.split_every_n(str(pdf), int(every_n))
+            else:
+                raise HTTPException(status_code=400, detail="Geçersiz mod")
+            all_outputs.extend(result.output_files)
+        except PDFSplitError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            logger.error(f"Split process error: {e}")
+            raise HTTPException(status_code=500, detail="PDF ayırma sırasında hata oluştu")
 
-        output_files = [os.path.basename(p) for p in result.output_files]
-        zip_name = os.path.basename(result.zip_path) if result.zip_path else None
+    if not all_outputs:
+        raise HTTPException(status_code=500, detail="Çıktı oluşturulamadı")
 
-        return {
-            "success": True,
-            "session_id": session_id,
-            "outputs": output_files,
-            "zip_file": zip_name,
-            "download_url": f"/api/tools/split/download/{session_id}/{zip_name}" if zip_name else None,
-        }
-    except PDFSplitError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Split process error: {e}")
-        raise HTTPException(status_code=500, detail="PDF ayırma sırasında hata oluştu")
+    zip_name = f"split_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+    zip_path = os.path.join(session_dir, zip_name)
+    with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for f in all_outputs:
+            zf.write(f, arcname=os.path.basename(f))
+
+    output_files = [os.path.basename(p) for p in all_outputs]
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "outputs": output_files,
+        "zip_file": zip_name,
+        "download_url": f"/api/tools/split/download/{session_id}/{zip_name}",
+    }
 
 
 @router.get("/download/{session_id}/{filename}")

--- a/app/routers/word_to_pdf.py
+++ b/app/routers/word_to_pdf.py
@@ -1,7 +1,8 @@
 import os
-from pathlib import Path
-from datetime import datetime
 import logging
+import zipfile
+from datetime import datetime
+from pathlib import Path
 
 from fastapi import APIRouter, File, UploadFile, HTTPException
 from fastapi.responses import FileResponse
@@ -18,16 +19,26 @@ router = APIRouter(prefix="/api/tools/word-to-pdf", tags=["word-to-pdf"])
 
 
 @router.post("/upload")
-async def upload_word_for_convert(file: UploadFile = File(...)):
-    validate_word_file(file)
+async def upload_word_for_convert(files: list[UploadFile] = File(...)):
+    if not files:
+        raise HTTPException(status_code=400, detail="Dosya yüklenmedi")
+
     session_id = datetime.now().strftime("%Y%m%d_%H%M%S_") + os.urandom(4).hex()
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     os.makedirs(session_dir, exist_ok=True)
 
+    saved_files = []
     try:
-        file_path = Path(session_dir) / file.filename
-        await save_upload_file(file, file_path)
-        return {"session_id": session_id, "file": {"original_name": file.filename, "path": str(file_path), "size": getattr(file, "size", 0)}}
+        for file in files:
+            validate_word_file(file)
+            file_path = Path(session_dir) / file.filename
+            await save_upload_file(file, file_path)
+            saved_files.append({
+                "original_name": file.filename,
+                "path": str(file_path),
+                "size": getattr(file, "size", 0),
+            })
+        return {"session_id": session_id, "files": saved_files}
     except Exception as e:
         if os.path.exists(session_dir):
             import shutil
@@ -45,23 +56,35 @@ async def process_word_to_pdf(session_id: str):
     docs = [str(p) for p in Path(session_dir).glob("*.doc*")]
     if not docs:
         raise HTTPException(status_code=400, detail="Word dosyası bulunamadı")
-    input_doc = docs[0]
 
     converter = WordToPDFConverter(temp_dir=session_dir)
-    try:
-        result = converter.convert(input_doc)
-        output_name = os.path.basename(result.output_path)
-        return {
-            "success": True,
-            "session_id": session_id,
-            "output_file": output_name,
-            "download_url": f"/api/tools/word-to-pdf/download/{session_id}/{output_name}",
-        }
-    except WordToPDFError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Word→PDF process error: {e}")
-        raise HTTPException(status_code=500, detail="Dönüştürme sırasında hata oluştu")
+    outputs = []
+    for doc in docs:
+        try:
+            result = converter.convert(doc)
+            outputs.append(result.output_path)
+        except WordToPDFError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            logger.error(f"Word→PDF process error: {e}")
+            raise HTTPException(status_code=500, detail="Dönüştürme sırasında hata oluştu")
+
+    if len(outputs) == 1:
+        output_name = os.path.basename(outputs[0])
+    else:
+        zip_name = f"word_to_pdf_{datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+        zip_path = os.path.join(session_dir, zip_name)
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for out in outputs:
+                zf.write(out, arcname=os.path.basename(out))
+        output_name = zip_name
+
+    return {
+        "success": True,
+        "session_id": session_id,
+        "output_file": output_name,
+        "download_url": f"/api/tools/word-to-pdf/download/{session_id}/{output_name}",
+    }
 
 
 @router.get("/download/{session_id}/{filename}")
@@ -70,6 +93,7 @@ async def download_converted(session_id: str, filename: str):
     file_path = os.path.join(session_dir, filename)
     if not os.path.exists(file_path):
         raise HTTPException(status_code=404, detail="Dosya bulunamadı")
-    return FileResponse(path=file_path, media_type="application/pdf", filename=filename)
+    media = "application/zip" if filename.lower().endswith('.zip') else "application/pdf"
+    return FileResponse(path=file_path, media_type=media, filename=filename)
 
 

--- a/site/about.html
+++ b/site/about.html
@@ -166,35 +166,13 @@
             </div>
         </section>
 
-        <!-- Values Section -->
+        <!-- Trust Section -->
         <section class="mb-16">
             <div class="bg-white rounded-xl shadow-md p-8">
-                <h2 class="text-3xl font-bold text-gray-800 mb-8 text-center">Değerlerimiz</h2>
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                    <div class="text-center">
-                        <div class="bg-red-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                            <i class="fas fa-heart text-red-600 text-2xl"></i>
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-800 mb-3">İnsan Odaklılık</h3>
-                        <p class="text-gray-600">Kullanıcılarımızın ihtiyaçlarını her zaman ön planda tutar, onların deneyimini sürekli iyileştirmeye odaklanırız.</p>
-                    </div>
-                    
-                    <div class="text-center">
-                        <div class="bg-blue-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                            <i class="fas fa-shield-alt text-blue-600 text-2xl"></i>
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-800 mb-3">Güvenlik</h3>
-                        <p class="text-gray-600">Kullanıcı verilerinin gizliliği ve güvenliği bizim için çok önemlidir. En yüksek güvenlik standartlarını uygularız.</p>
-                    </div>
-                    
-                    <div class="text-center">
-                        <div class="bg-green-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                            <i class="fas fa-leaf text-green-600 text-2xl"></i>
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-800 mb-3">Sürdürülebilirlik</h3>
-                        <p class="text-gray-600">Çevre dostu teknolojiler kullanarak, gelecek nesillere daha iyi bir dünya bırakmaya katkıda bulunuruz.</p>
-                    </div>
-                </div>
+                <h2 class="text-3xl font-bold text-gray-800 mb-4 text-center">Bize Nasıl Güvenebilirsin?</h2>
+                <p class="text-gray-600 text-center max-w-3xl mx-auto">
+                    Yüklediğiniz dosyalar asla sunucularımızda kalıcı olarak saklanmaz. Belgeleriniz yalnızca talep ettiğiniz işlemleri gerçekleştirmek için geçici olarak kullanılır ve işlem tamamlandığında sistemimizden otomatik olarak silinir. Veri güvenliği konusunda en yüksek standartları uyguluyor, gizliliğinizi her zaman ön planda tutuyoruz.
+                </p>
             </div>
         </section>
 

--- a/site/js/modules/api.js
+++ b/site/js/modules/api.js
@@ -150,9 +150,9 @@ class PDFApi {
     }
 
     // ===== Split APIs =====
-    async uploadFileForSplit(file) {
+    async uploadFilesForSplit(files) {
         const formData = new FormData();
-        formData.append('file', file);
+        files.forEach(f => formData.append('files', f));
         const response = await fetch(`${this.baseUrl}/tools/split/upload`, { method: 'POST', body: formData });
         if (!response.ok) {
             const err = await response.json().catch(() => ({}));
@@ -204,9 +204,9 @@ class PDFApi {
     }
 
     // ===== PDF → Word APIs =====
-    async uploadFileForPdfToWord(file) {
+    async uploadFilesForPdfToWord(files) {
         const formData = new FormData();
-        formData.append('file', file);
+        files.forEach(f => formData.append('files', f));
         const response = await fetch(`${this.baseUrl}/tools/pdf-to-word/upload`, { method: 'POST', body: formData });
         if (!response.ok) {
             const err = await response.json().catch(() => ({}));
@@ -228,9 +228,9 @@ class PDFApi {
         return `${this.baseUrl}/tools/pdf-to-word/download/${sessionId}/${filename}`;
     }
     // ===== Word → PDF APIs =====
-    async uploadFileForWordToPdf(file) {
+    async uploadFilesForWordToPdf(files) {
         const formData = new FormData();
-        formData.append('file', file);
+        files.forEach(f => formData.append('files', f));
         const response = await fetch(`${this.baseUrl}/tools/word-to-pdf/upload`, { method: 'POST', body: formData });
         if (!response.ok) {
             const err = await response.json().catch(() => ({}));
@@ -253,9 +253,9 @@ class PDFApi {
     }
 
     // ===== PDF → PPT APIs =====
-    async uploadFileForPdfToPpt(file) {
+    async uploadFilesForPdfToPpt(files) {
         const formData = new FormData();
-        formData.append('file', file);
+        files.forEach(f => formData.append('files', f));
         const response = await fetch(`${this.baseUrl}/tools/pdf-to-ppt/upload`, { method: 'POST', body: formData });
         if (!response.ok) {
             const err = await response.json().catch(() => ({}));
@@ -399,9 +399,9 @@ class PDFApi {
     }
 
     // ===== PDF → JPG APIs =====
-    async uploadFileForPdfToJpg(file) {
+    async uploadFilesForPdfToJpg(files) {
         const formData = new FormData();
-        formData.append('file', file);
+        files.forEach(f => formData.append('files', f));
         const res = await fetch(`${this.baseUrl}/tools/pdf-to-jpg/upload`, { method: 'POST', body: formData });
         if (!res.ok) {
             const err = await res.json().catch(() => ({}));

--- a/site/js/modules/fileHandler.js
+++ b/site/js/modules/fileHandler.js
@@ -31,7 +31,8 @@ class FileHandler {
         const fileInput = document.getElementById('fileInput');
         if (fileInput) {
             fileInput.addEventListener('change', (e) => {
-                this.handleFiles(e.target.files);
+                const tool = window.toolManager?.getCurrentTool();
+                this.handleFiles(e.target.files, tool);
             });
         }
 
@@ -50,7 +51,8 @@ class FileHandler {
             fileDropArea.addEventListener('drop', (e) => {
                 e.preventDefault();
                 fileDropArea.classList.remove('dragover');
-                this.handleFiles(e.dataTransfer.files);
+                const tool = window.toolManager?.getCurrentTool();
+                this.handleFiles(e.dataTransfer.files, tool);
             });
         }
     }

--- a/site/js/modules/toolManager.js
+++ b/site/js/modules/toolManager.js
@@ -102,9 +102,17 @@ class ToolManager {
      * Araç aç
      */
     openTool(toolName) {
+        if (this.currentTool && this.currentTool !== toolName) {
+            fileHandler.reset();
+        }
         this.currentTool = toolName;
-        
-        // Tool interface'i göster
+
+        // accept attribute update
+        const fileInput = document.getElementById('fileInput');
+        if (fileInput) {
+            fileInput.accept = toolName === 'word-to-pdf' ? '.doc,.docx' : '.pdf';
+        }
+
         const toolInterface = document.getElementById('toolInterface');
         if (toolInterface) {
             this.populateToolInterface(toolName);
@@ -112,7 +120,6 @@ class ToolManager {
             toolInterface.scrollIntoView({ behavior: 'smooth' });
         }
 
-        // Analytics
         this.trackEvent('tool_opened', { tool_name: toolName });
     }
 
@@ -120,16 +127,22 @@ class ToolManager {
      * Dosyalarla birlikte araç aç
      */
     openToolWithFiles(toolName, files) {
+        if (this.currentTool && this.currentTool !== toolName) {
+            fileHandler.reset();
+        }
         this.currentTool = toolName;
-        
-        // Tool interface'i göster
+
+        const fileInput = document.getElementById('fileInput');
+        if (fileInput) {
+            fileInput.accept = toolName === 'word-to-pdf' ? '.doc,.docx' : '.pdf';
+        }
+
         const toolInterface = document.getElementById('toolInterface');
         if (toolInterface) {
             this.populateToolInterface(toolName);
             toolInterface.classList.remove('hidden');
         }
-        
-        // Önce dosyaları yükle
+
         fileHandler.handleFiles(files, toolName);
         
         // Dosya yükleme tamamlandıktan sonra scroll yap

--- a/site/js/tools/pdf-to-jpg.js
+++ b/site/js/tools/pdf-to-jpg.js
@@ -11,12 +11,12 @@ class PdfToJpgTool {
 
     async process(){
         const files = fileHandler.getSelectedFiles();
-        if (files.length !== 1){ notifications.error('Lütfen tek bir PDF yükleyin'); return; }
+        if (files.length === 0){ notifications.error('Lütfen PDF dosyaları yükleyin'); return; }
         const btn = document.getElementById('processButton');
         if (btn) btn.disabled = true;
         try {
-            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: 'Dosya yükleniyor' });
-            const up = await pdfApi.uploadFileForPdfToJpg(files[0]);
+            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: 'Dosyalar yükleniyor' });
+            const up = await pdfApi.uploadFilesForPdfToJpg(files);
             const sessionId = up.session_id;
             pdfLoader.updateProgress(50, 'Sayfalar dönüştürülüyor...');
             const result = await pdfApi.processPdfToJpg(sessionId);

--- a/site/js/tools/pdf-to-ppt.js
+++ b/site/js/tools/pdf-to-ppt.js
@@ -11,14 +11,14 @@ class PdfToPptTool {
 
     async process(){
         const files = fileHandler.getSelectedFiles();
-        if (files.length !== 1) { notifications.error('Lütfen tek bir PDF yükleyin'); return; }
+        if (files.length === 0) { notifications.error('Lütfen PDF dosyaları yükleyin'); return; }
 
         const btn = document.getElementById('processButton');
         if (btn) btn.disabled = true;
 
         try{
-            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `Dosya yükleniyor` });
-            const up = await pdfApi.uploadFileForPdfToPpt(files[0]);
+            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `Dosyalar yükleniyor` });
+            const up = await pdfApi.uploadFilesForPdfToPpt(files);
             const sessionId = up.session_id;
 
             pdfLoader.updateProgress(50, 'Slaytlar hazırlanıyor...');
@@ -47,7 +47,7 @@ class PdfToPptTool {
         }
 
         resultArea.classList.remove('hidden');
-        notifications.success(`PPT hazır! Toplam ${result.page_count} slayt oluşturuldu. 📽️`);
+        notifications.success('PPT hazır! İndirme başlatıldı. 📽️');
     }
 
     getOptions(){ return ''; }

--- a/site/js/tools/pdf-to-word.js
+++ b/site/js/tools/pdf-to-word.js
@@ -11,15 +11,15 @@ class PdfToWordTool {
 
     async process(){
         const files = fileHandler.getSelectedFiles();
-        if (files.length !== 1) { notifications.error('Lütfen tek bir PDF yükleyin'); return; }
+        if (files.length === 0) { notifications.error('Lütfen PDF dosyaları yükleyin'); return; }
 
         const btn = document.getElementById('processButton');
         if (btn) btn.disabled = true;
 
         try{
-            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `Dosya yükleniyor` });
+            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `Dosyalar yükleniyor` });
 
-            const up = await pdfApi.uploadFileForPdfToWord(files[0]);
+            const up = await pdfApi.uploadFilesForPdfToWord(files);
             const sessionId = up.session_id;
 
             pdfLoader.updateProgress(50, 'Word dönüştürme başlatılıyor...');

--- a/site/js/tools/split.js
+++ b/site/js/tools/split.js
@@ -15,8 +15,8 @@ class SplitTool {
 
     async process() {
         const files = fileHandler.getSelectedFiles();
-        if (files.length !== 1) {
-            notifications.error('Lütfen sadece 1 PDF yükleyin');
+        if (files.length === 0) {
+            notifications.error('Lütfen PDF dosyaları yükleyin');
             return;
         }
 
@@ -24,10 +24,10 @@ class SplitTool {
         if (processButton) processButton.disabled = true;
 
         try {
-            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `Dosya yükleniyor` });
+            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `Dosyalar yükleniyor` });
 
             // Upload
-            const upload = await pdfApi.uploadFileForSplit(files[0]);
+            const upload = await pdfApi.uploadFilesForSplit(files);
             const sessionId = upload.session_id;
 
             // Options

--- a/site/js/tools/word-to-pdf.js
+++ b/site/js/tools/word-to-pdf.js
@@ -11,16 +11,19 @@ class WordToPdfTool {
 
     async process(){
         const files = fileHandler.getSelectedFiles();
-        if (files.length !== 1) { notifications.error('Lütfen tek bir Word dosyası (DOC/DOCX) yükleyin'); return; }
-        const name = files[0].name.toLowerCase();
-        if (!(name.endsWith('.doc') || name.endsWith('.docx'))) { notifications.error('Geçerli Word dosyası seçin (DOC/DOCX)'); return; }
+        if (files.length === 0) { notifications.error('Lütfen Word dosyaları yükleyin'); return; }
+        const invalid = files.some(f => {
+            const n = f.name.toLowerCase();
+            return !(n.endsWith('.doc') || n.endsWith('.docx'));
+        });
+        if (invalid) { notifications.error('Geçerli Word dosyaları seçin (DOC/DOCX)'); return; }
 
         const btn = document.getElementById('processButton');
         if (btn) btn.disabled = true;
 
         try{
-            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `Dosya yükleniyor` });
-            const up = await pdfApi.uploadFileForWordToPdf(files[0]);
+            pdfLoader.show({ message: `${this.toolName} işleniyor...`, subMessage: `Dosyalar yükleniyor` });
+            const up = await pdfApi.uploadFilesForWordToPdf(files);
             const sessionId = up.session_id;
 
             pdfLoader.updateProgress(50, 'PDF dönüştürme başlatılıyor...');


### PR DESCRIPTION
## Summary
- Support multiple file uploads with ZIP downloads for PDF↔Word, PDF↔JPG, PDF↔PPT, and PDF split tools
- Clear selected files and adjust file input types when switching tools to avoid tool selection errors
- Replaced “Değerlerimiz” section with data privacy explanation under “Bize Nasıl Güvenebilirsin?”

## Testing
- `python -m py_compile app/routers/pdf_to_word.py app/routers/word_to_pdf.py app/routers/pdf_to_jpg.py app/routers/pdf_to_ppt.py app/routers/split.py`


------
https://chatgpt.com/codex/tasks/task_e_68b49016a6188327b93a2f930a0eac5b