### PR TITLE
fix meta tag for pdf merge blog

### DIFF
--- a/site/blog/pdf-birlestirme.html
+++ b/site/blog/pdf-birlestirme.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PDF Birleştirme - PDFişlemleri.com</title>
-    <meta name="content" content="Çoklu PDF dosyalarını tek bir belgede birleştirme işlemini adım adım öğrenin. PDF birleştirme rehberi ve araçları.">
+    <meta name="description" content="Çoklu PDF dosyalarını tek bir belgede birleştirme işlemini adım adım öğrenin. PDF birleştirme rehberi ve araçları.">
     <meta name="keywords" content="pdf birleştirme, pdf birleştir, birden fazla pdf birleştirme, pdf dosya birleştirme, online pdf birleştirici">
     <meta name="author" content="PDFişlemleri.com">
     <meta name="robots" content="index, follow">


### PR DESCRIPTION
## Summary
- replace `meta name="content"` with `meta name="description"` in pdf merge blog page

## Testing
- `npx html-validate site/blog/pdf-birlestirme.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-validate)*

------
https://chatgpt.com/codex/tasks/task_e_68b91bbfbd8083279871c81a7253f1e2