### PR TITLE
Replace anchor links with dedicated tool URLs in sitemap

### DIFF
--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -7,73 +7,73 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#merge</loc>
+      <loc>https://pdfislemleri.com/merge</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#split</loc>
+      <loc>https://pdfislemleri.com/split</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#compress</loc>
+      <loc>https://pdfislemleri.com/compress</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#pdf-to-word</loc>
+      <loc>https://pdfislemleri.com/pdf-to-word</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#word-to-pdf</loc>
+      <loc>https://pdfislemleri.com/word-to-pdf</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#pdf-to-ppt</loc>
+      <loc>https://pdfislemleri.com/pdf-to-ppt</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#unlock</loc>
+      <loc>https://pdfislemleri.com/unlock</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#protect</loc>
+      <loc>https://pdfislemleri.com/protect</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#rotate</loc>
+      <loc>https://pdfislemleri.com/rotate</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#watermark</loc>
+      <loc>https://pdfislemleri.com/watermark</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#pdf-to-jpg</loc>
+      <loc>https://pdfislemleri.com/pdf-to-jpg</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdfislemleri.com/#organize</loc>
+      <loc>https://pdfislemleri.com/organize</loc>
     <lastmod>2024-12-15</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
## Summary
- remove `#` anchor links for tool entries in sitemap, using dedicated page URLs
- add missing newline at end of sitemap

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b91c65d000832782914eb5f4797bfa