### PR TITLE
Avoid unnecessary BackgroundTasks instantiation

### DIFF
--- a/app/routers/merge.py
+++ b/app/routers/merge.py
@@ -21,8 +21,8 @@ router = APIRouter(prefix="/api/tools/merge", tags=["merge"])
 
 @router.post("/upload")
 async def upload_pdfs_for_merge(
+    background_tasks: BackgroundTasks,
     files: List[UploadFile] = File(...),
-    background_tasks: BackgroundTasks = BackgroundTasks(),
 ):
     if len(files) < 2:
         raise HTTPException(status_code=400, detail="En az 2 PDF dosyası gereklidir")
@@ -57,7 +57,8 @@ async def upload_pdfs_for_merge(
             })
             logger.info(f"Dosya yüklendi: {file.filename}")
 
-        background_tasks.add_task(cleanup_old_files)
+        if background_tasks:
+            background_tasks.add_task(cleanup_old_files)
 
         return {
             "session_id": session_id,
@@ -78,8 +79,8 @@ async def upload_pdfs_for_merge(
 @router.post("/process/{session_id}")
 async def process_merge(
     session_id: str,
+    background_tasks: BackgroundTasks,
     sort_by_name: bool = False,
-    background_tasks: BackgroundTasks = BackgroundTasks(),
 ):
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     if not os.path.exists(session_dir):

--- a/app/routers/organize.py
+++ b/app/routers/organize.py
@@ -29,8 +29,8 @@ class PageOrder(BaseModel):
 
 @router.post("/upload")
 async def upload_pdfs_for_organize(
+    background_tasks: BackgroundTasks,
     files: List[UploadFile] = File(...),
-    background_tasks: BackgroundTasks = BackgroundTasks(),
 ):
     if len(files) == 0:
         raise HTTPException(status_code=400, detail="En az 1 PDF dosyası gereklidir")
@@ -67,7 +67,8 @@ async def upload_pdfs_for_organize(
             )
             logger.info(f"Dosya yüklendi: {file.filename}")
 
-        background_tasks.add_task(cleanup_old_files)
+        if background_tasks:
+            background_tasks.add_task(cleanup_old_files)
 
         return {
             "session_id": session_id,
@@ -88,7 +89,7 @@ async def upload_pdfs_for_organize(
 async def process_organize(
     session_id: str,
     page_order: PageOrder,
-    background_tasks: BackgroundTasks = BackgroundTasks(),
+    background_tasks: BackgroundTasks,
 ):
     session_dir = os.path.join(settings.TEMP_DIR, session_id)
     if not os.path.exists(session_dir):


### PR DESCRIPTION
## Summary
- Remove default `BackgroundTasks()` values from merge and organize routers
- Guard cleanup job scheduling with a BackgroundTasks check

## Testing
- `python -m py_compile app/routers/merge.py app/routers/organize.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b91c4ab23c8327b83db03d18dc64c4