### PR TITLE
Update OG/Twitter images to JPEG

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -38,10 +38,10 @@
     <meta property="og:url" content="https://pdfislemleri.com/about">
     <meta property="og:title" content="Hakkımızda - PDFişlemleri.com">
     <meta property="og:description" content="PDFişlemleri.com hakkında detaylı bilgi. Misyonumuz, vizyonumuz ve değerlerimiz.">
-    <meta property="og:image" content="https://pdfislemleri.com/images/about-og.webp">
+    <meta property="og:image" content="https://pdfislemleri.com/images/about-og.jpeg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:type" content="image/webp">
+    <meta property="og:image:type" content="image/jpeg">
     <meta property="og:site_name" content="PDFişlemleri.com">
     <meta property="og:locale" content="tr_TR">
     
@@ -50,7 +50,7 @@
     <meta property="twitter:url" content="https://pdfislemleri.com/about">
     <meta property="twitter:title" content="Hakkımızda - PDFişlemleri.com">
     <meta property="twitter:description" content="PDFişlemleri.com hakkında detaylı bilgi. Misyonumuz, vizyonumuz ve değerlerimiz.">
-    <meta property="twitter:image" content="https://pdfislemleri.com/images/about-og.webp">
+    <meta property="twitter:image" content="https://pdfislemleri.com/images/about-og.jpeg">
     
     <!-- PWA Manifest -->
     <link rel="manifest" href="/icons/site.webmanifest">

--- a/site/blog.html
+++ b/site/blog.html
@@ -38,10 +38,10 @@
     <meta property="og:url" content="https://pdfislemleri.com/blog">
     <meta property="og:title" content="Blog - PDFişlemleri.com | PDF İpuçları ve Rehberler">
     <meta property="og:description" content="PDF dosyalarıyla ilgili tüm sorunlarınıza çözüm bulun! Adım adım rehberler ve pratik ipuçları.">
-    <meta property="og:image" content="https://pdfislemleri.com/images/blog-og.webp">
+    <meta property="og:image" content="https://pdfislemleri.com/images/blog-og.jpeg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:type" content="image/webp">
+    <meta property="og:image:type" content="image/jpeg">
     <meta property="og:site_name" content="PDFişlemleri.com">
     <meta property="og:locale" content="tr_TR">
     
@@ -50,7 +50,7 @@
     <meta property="twitter:url" content="https://pdfislemleri.com/blog">
     <meta property="twitter:title" content="Blog - PDFişlemleri.com | PDF İpuçları ve Rehberler">
     <meta property="twitter:description" content="PDF dosyalarıyla ilgili tüm sorunlarınıza çözüm bulun! Adım adım rehberler ve pratik ipuçları.">
-    <meta property="twitter:image" content="https://pdfislemleri.com/images/blog-og.webp">
+    <meta property="twitter:image" content="https://pdfislemleri.com/images/blog-og.jpeg">
     
     <!-- PWA Manifest -->
     <link rel="manifest" href="/icons/site.webmanifest">

--- a/site/index.html
+++ b/site/index.html
@@ -33,10 +33,10 @@
     <meta property="og:url" content="https://pdfislemleri.com">
     <meta property="og:title" content="PDFişlemleri.com - Ücretsiz PDF Araçları">
     <meta property="og:description" content="PDF dosyalarınızı ücretsiz birleştirin, ayırın, sıkıştırın. Hızlı, güvenli ve kullanımı kolay PDF araçları.">
-    <meta property="og:image" content="https://pdfislemleri.com/images/home-og.webp">
+    <meta property="og:image" content="https://pdfislemleri.com/images/home-og.jpeg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:type" content="image/webp">
+    <meta property="og:image:type" content="image/jpeg">
     <meta property="og:site_name" content="PDFişlemleri.com">
     <meta property="og:locale" content="tr_TR">
     
@@ -45,7 +45,7 @@
     <meta property="twitter:url" content="https://pdfislemleri.com">
     <meta property="twitter:title" content="PDFişlemleri.com - Ücretsiz PDF Araçları">
     <meta property="twitter:description" content="PDF dosyalarınızı ücretsiz birleştirin, ayırın, sıkıştırın. Hızlı, güvenli ve kullanımı kolay PDF araçları.">
-    <meta property="twitter:image" content="https://pdfislemleri.com/images/home-og.webp">
+    <meta property="twitter:image" content="https://pdfislemleri.com/images/home-og.jpeg">
     
     <!-- PWA Manifest -->
     <link rel="manifest" href="/icons/site.webmanifest">


### PR DESCRIPTION
## Summary
- Switch Open Graph and Twitter preview images to JPEG versions on index, about, and blog pages
- Set Open Graph image types to `image/jpeg` for accurate metadata

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9828c65c8327b30b36fa7336186b