### PR TITLE
feat: configure CORS origins via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration for PDFişlemleri.com
+# List of allowed origins for CORS (JSON array)
+# Update in production to the domains you wish to allow
+ALLOW_ORIGINS=["https://pdfislemleri.com", "https://www.pdfislemleri.com"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ PDF işlemleri için modern web uygulaması, Caddy + Docker Compose ile canlıya
 - **Performans**: zstd/gzip sıkıştırma, cache politikaları
 - **CSS Yapısı**: Modülerleştirilmiş stil dosyaları (`base.css`, `components.css`, `theme.css`) ile daha düzenli ve ölçeklenebilir frontend geliştirme
 
+## ⚙️ Environment
+
+CORS için izin verilen alan adları `.env` dosyasındaki `ALLOW_ORIGINS` değeri ile yapılandırılır. Format olarak JSON dizisi kullanılmalıdır; örnek için `.env.example` dosyasına bakabilirsiniz.
+
 ## 📁 Proje Yapısı
 
 C:.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,12 +2,14 @@ import os
 import tempfile
 from typing import List
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 
 
 class Settings(BaseSettings):
     """Application configuration loaded from environment with sensible defaults."""
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     # File system and resource limits
     TEMP_DIR: str = Field(default_factory=lambda: os.environ.get("TEMP_DIR", os.path.join(tempfile.gettempdir(), "pdfislemleri")))
@@ -24,9 +26,6 @@ class Settings(BaseSettings):
         "http://localhost:80",
         "http://localhost:3000",
         "http://localhost:8000",
-        "https://pdfislemleri.com",
-        "https://www.pdfislemleri.com",
-        "*"  # Development için geçici
     ])
     ALLOW_CREDENTIALS: bool = True
     ALLOW_METHODS: List[str] = Field(default_factory=lambda: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"])


### PR DESCRIPTION
## Summary
- remove wildcard from CORS allowed origins
- load allowed origins from `.env`
- document environment configuration

## Testing
- `python -m pytest`
- `python -m py_compile app/core/config.py`


------
https://chatgpt.com/codex/tasks/task_e_68c412a497c483279a5e667cf151301f