### PR TITLE
Move security headers to caddy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,9 +12,13 @@ localhost {
   
   # Güvenlik başlıkları
   header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+    Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://cdn.tailwindcss.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://cdn.tailwindcss.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'"
     X-Content-Type-Options "nosniff"
     X-Frame-Options "DENY"
+    X-XSS-Protection "1; mode=block"
     Referrer-Policy "strict-origin-when-cross-origin"
+    Permissions-Policy "geolocation=(), microphone=(), camera=()"
   }
   
   # Statik dosyalar ve SPA routing

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -1,8 +1,6 @@
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.middleware.base import RequestResponseEndpoint
-from starlette.responses import Response
 
 from .config import settings
 
@@ -26,44 +24,7 @@ class FileSizeLimitMiddleware(BaseHTTPMiddleware):
         return response
 
 
-class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    """Middleware to add security headers"""
-    
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        response = await call_next(request)
-        
-        # Content Security Policy - Google Analytics ve Tailwind için optimize
-        response.headers["Content-Security-Policy"] = (
-            "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' "
-            "https://www.googletagmanager.com https://www.google-analytics.com "
-            "https://cdn.tailwindcss.com https://cdnjs.cloudflare.com; "
-            "style-src 'self' 'unsafe-inline' "
-            "https://cdnjs.cloudflare.com https://fonts.googleapis.com "
-            "https://cdn.tailwindcss.com; "
-            "font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; "
-            "img-src 'self' data: https: blob:; "
-            "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com; "
-            "frame-src 'none'; "
-            "object-src 'none'; "
-            "base-uri 'self'; "
-            "form-action 'self'"
-        )
-        
-        # Other security headers
-        response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["X-Frame-Options"] = "DENY"
-        response.headers["X-XSS-Protection"] = "1; mode=block"
-        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-        response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
-        
-        return response
-
-
 def setup_cors(app: FastAPI) -> None:
-    # Add security headers middleware first
-    app.add_middleware(SecurityHeadersMiddleware)
-    
     # Add CORS middleware
     app.add_middleware(
         CORSMiddleware,

--- a/caddy-sites/pdfislemleri.com.Caddyfile
+++ b/caddy-sites/pdfislemleri.com.Caddyfile
@@ -33,10 +33,13 @@ pdfislemleri.com {
   }
 
   header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+    Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://cdn.tailwindcss.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://cdn.tailwindcss.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' data: https: blob:; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'"
     X-Content-Type-Options "nosniff"
     X-Frame-Options "DENY"
+    X-XSS-Protection "1; mode=block"
     Referrer-Policy "strict-origin-when-cross-origin"
-    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+    Permissions-Policy "geolocation=(), microphone=(), camera=()"
   }
 
   log {


### PR DESCRIPTION
## Summary
- serve CSP and other security headers via Caddy instead of FastAPI
- drop FastAPI security header middleware to avoid duplication

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c41301657883279db59cc436743b55