### PR TITLE
build: configure asset pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 *.pyc
 .env
+node_modules/
+site/dist/

--- a/Caddyfile
+++ b/Caddyfile
@@ -4,6 +4,18 @@ localhost {
   
   # Ana site root
   root * /srv
+
+  handle_path /css/* {
+    root * /srv/dist/css
+    header Cache-Control "public, max-age=31536000, immutable"
+    file_server
+  }
+
+  handle_path /js/* {
+    root * /srv/dist/js
+    header Cache-Control "public, max-age=31536000, immutable"
+    file_server
+  }
   
   # API yönlendirmesi
   handle /api/* {

--- a/caddy-sites/pdfislemleri.com.Caddyfile
+++ b/caddy-sites/pdfislemleri.com.Caddyfile
@@ -19,8 +19,20 @@ pdfislemleri.com {
 
   root * /srv/pdfislemleri
 
+  handle_path /css/* {
+    root * /srv/pdfislemleri/dist/css
+    header Cache-Control "public, max-age=31536000, immutable"
+    file_server
+  }
+
+  handle_path /js/* {
+    root * /srv/pdfislemleri/dist/js
+    header Cache-Control "public, max-age=31536000, immutable"
+    file_server
+  }
+
   @static {
-    path_regexp static ^/(?:images|icons|cardbgs|css|js)/.*|.*\.(?:css|js|png|jpg|jpeg|webp|svg|ico|xml|txt|woff2?)$
+    path_regexp static ^/(?:images|icons|cardbgs)/.*|.*\.(?:css|js|png|jpg|jpeg|webp|svg|ico|xml|txt|woff2?)$
   }
   header @static Cache-Control "public, max-age=31536000, immutable"
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pdfislemleri-site",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build:css": "tailwindcss -c tailwind.config.js -i ./site/css/base.css -o ./site/dist/css/base.css --minify && tailwindcss -c tailwind.config.js -i ./site/css/components.css -o ./site/dist/css/components.css --minify && tailwindcss -c tailwind.config.js -i ./site/css/gradients.css -o ./site/dist/css/gradients.css --minify && tailwindcss -c tailwind.config.js -i ./site/css/theme.css -o ./site/dist/css/theme.css --minify",
+    "build:js": "vite build",
+    "build": "npm run build:css && npm run build:js"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  content: ["./site/**/*.{html,js}"],
+  corePlugins: {
+    preflight: false,
+  },
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,22 @@
+import { resolve } from 'path';
+
+export default {
+  build: {
+    outDir: 'site/dist',
+    emptyOutDir: false,
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'site/js/main.js'),
+        themeManager: resolve(__dirname, 'site/js/theme-manager.js'),
+        gtm: resolve(__dirname, 'site/js/gtm.js'),
+        gtagConfig: resolve(__dirname, 'site/js/gtag-config.js'),
+        tailwindConfig: resolve(__dirname, 'site/js/tailwind-config.js'),
+      },
+      output: {
+        entryFileNames: 'js/[name].js',
+        chunkFileNames: 'js/[name].js',
+        assetFileNames: 'js/[name][extname]'
+      }
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add node-based pipeline to compile site CSS and JS
- publish built assets from `site/dist` via Caddy `handle_path`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: tailwindcss: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c41a7653ac83278b6c40b77348e2dc