### PR TITLE
feat: extend session timeout to 5 minutes

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
 
     # Cleanup and session
     FILE_CLEANUP_HOURS: int = 24
-    SESSION_LIFETIME_MINUTES: int = 1
+    SESSION_LIFETIME_MINUTES: int = 5
 
     # CORS
     ALLOW_ORIGINS: List[str] = Field(default_factory=lambda: [

--- a/site/js/modules/fileHandler.js
+++ b/site/js/modules/fileHandler.js
@@ -17,8 +17,8 @@ class FileHandler {
         this.MAX_FILES = 10;
         this.MAX_TOTAL_SIZE = 100 * 1024 * 1024; // 100MB
         
-        // Session süresi (1 dakika)
-        this.SESSION_LIFETIME_MINUTES = 1;
+        // Session süresi (5 dakika)
+        this.SESSION_LIFETIME_MINUTES = 5;
         
         this.initializeEventListeners();
     }


### PR DESCRIPTION
## Summary
- align session lifetime to 5 minutes in backend and frontend

## Testing
- `python -m py_compile app/core/config.py`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tailwindcss)*
- `npm run build:js` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c435c7f0508327af87c7a9b49ab6d8