### PR TITLE
Add pytest tests, config and README instructions for PDF tool endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,22 @@ Frontend, backend'den dinamik olarak konfigürasyon alır:
 - Domain DNS ayarları
 - Docker & Docker Compose
 
+## 🧪 Testler (Pytest)
+
+Pytest testleri PDF araçlarının upload/process uçlarını doğrular.
+
+```bash
+# Sanal ortam (opsiyonel)
+python -m venv .venv
+source .venv/bin/activate
+
+# Backend bağımlılıkları + pytest
+pip install -r app/requirements.txt
+
+# Testleri çalıştır
+pytest
+```
+
 ### 1. Proje Yapısını Oluştur
 
 ```bash

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -27,3 +27,6 @@ aiofiles==23.2.1
 pydantic-settings==2.3.4
 requests==2.31.0
 slowapi==0.1.9
+
+# Testing
+pytest==8.3.2

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core.config import settings
+from main import app
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "TEMP_DIR", str(tmp_path))
+    os.makedirs(settings.TEMP_DIR, exist_ok=True)
+    return TestClient(app)

--- a/app/tests/test_tools_process.py
+++ b/app/tests/test_tools_process.py
@@ -1,0 +1,67 @@
+import pytest
+
+
+PROCESS_CASES = [
+    {"name": "merge", "path": "/api/tools/merge/process/{session_id}"},
+    {"name": "split", "path": "/api/tools/split/process/{session_id}"},
+    {"name": "compress", "path": "/api/tools/compress/process/{session_id}"},
+    {"name": "pdf-to-word", "path": "/api/tools/pdf-to-word/process/{session_id}"},
+    {"name": "word-to-pdf", "path": "/api/tools/word-to-pdf/process/{session_id}"},
+    {"name": "pdf-to-ppt", "path": "/api/tools/pdf-to-ppt/process/{session_id}"},
+    {
+        "name": "protect",
+        "path": "/api/tools/protect/process/{session_id}",
+        "data": {"user_password": "secret"},
+    },
+    {
+        "name": "unlock",
+        "path": "/api/tools/unlock/process/{session_id}",
+        "data": {"password": "secret"},
+    },
+    {"name": "rotate", "path": "/api/tools/rotate/process/{session_id}"},
+    {
+        "name": "watermark",
+        "path": "/api/tools/watermark/process/{session_id}",
+        "params": {"text": "Test"},
+    },
+    {"name": "pdf-to-jpg", "path": "/api/tools/pdf-to-jpg/process/{session_id}"},
+    {
+        "name": "organize",
+        "path": "/api/tools/organize/process/{session_id}",
+        "json": {"pages": []},
+    },
+    {
+        "name": "sign",
+        "path": "/api/tools/sign/process/{session_id}",
+        "data": {
+            "name": "Ada",
+            "surname": "Lovelace",
+            "signature_data": "data:image/png;base64,AAA",
+            "signature_type": "drawn",
+            "opacity": "0.8",
+            "selected_files": "[]",
+            "signature_positions": "{}",
+        },
+    },
+    {
+        "name": "pdf-ocr",
+        "path": "/api/tools/pdf-ocr/process/{session_id}",
+        "data": {"language": "tur+eng"},
+    },
+    {"name": "pdf-to-excel", "path": "/api/tools/pdf-to-excel/process/{session_id}"},
+    {"name": "pdf-to-txt", "path": "/api/tools/pdf-to-txt/process/{session_id}"},
+]
+
+
+@pytest.mark.parametrize(
+    "case", PROCESS_CASES, ids=[case["name"] for case in PROCESS_CASES]
+)
+def test_process_endpoints_missing_session_return_404(client, case):
+    session_id = "missing-session"
+    response = client.post(
+        case["path"].format(session_id=session_id),
+        params=case.get("params"),
+        data=case.get("data"),
+        json=case.get("json"),
+    )
+    assert response.status_code == 404, response.text

--- a/app/tests/test_tools_uploads.py
+++ b/app/tests/test_tools_uploads.py
@@ -1,0 +1,133 @@
+import pytest
+
+
+PDF_BYTES = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+DOCX_BYTES = b"PK\x03\x04DOCX"
+
+
+UPLOAD_CASES = [
+    {
+        "name": "merge",
+        "path": "/api/tools/merge/upload",
+        "field": "files",
+        "files": [
+            ("first.pdf", PDF_BYTES, "application/pdf"),
+            ("second.pdf", PDF_BYTES, "application/pdf"),
+        ],
+    },
+    {
+        "name": "split",
+        "path": "/api/tools/split/upload",
+        "field": "files",
+        "files": [("split.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "compress",
+        "path": "/api/tools/compress/upload",
+        "field": "files",
+        "files": [("compress.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "pdf-to-word",
+        "path": "/api/tools/pdf-to-word/upload",
+        "field": "files",
+        "files": [("convert.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "word-to-pdf",
+        "path": "/api/tools/word-to-pdf/upload",
+        "field": "files",
+        "files": [
+            (
+                "document.docx",
+                DOCX_BYTES,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+        ],
+    },
+    {
+        "name": "pdf-to-ppt",
+        "path": "/api/tools/pdf-to-ppt/upload",
+        "field": "files",
+        "files": [("slides.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "protect",
+        "path": "/api/tools/protect/upload",
+        "field": "files",
+        "files": [("secure.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "unlock",
+        "path": "/api/tools/unlock/upload",
+        "field": "file",
+        "files": [("locked.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "rotate",
+        "path": "/api/tools/rotate/upload",
+        "field": "files",
+        "files": [("rotate.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "watermark",
+        "path": "/api/tools/watermark/upload",
+        "field": "files",
+        "files": [("watermark.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "pdf-to-jpg",
+        "path": "/api/tools/pdf-to-jpg/upload",
+        "field": "files",
+        "files": [("images.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "organize",
+        "path": "/api/tools/organize/upload",
+        "field": "files",
+        "files": [("organize.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "sign",
+        "path": "/api/tools/sign/upload",
+        "field": "files",
+        "files": [("sign.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "pdf-ocr",
+        "path": "/api/tools/pdf-ocr/upload",
+        "field": "files",
+        "files": [("ocr.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "pdf-to-excel",
+        "path": "/api/tools/pdf-to-excel/upload",
+        "field": "files",
+        "files": [("table.pdf", PDF_BYTES, "application/pdf")],
+    },
+    {
+        "name": "pdf-to-txt",
+        "path": "/api/tools/pdf-to-txt/upload",
+        "field": "files",
+        "files": [
+            ("report.pdf", PDF_BYTES, "application/pdf"),
+            (
+                "report.docx",
+                DOCX_BYTES,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            ),
+        ],
+    },
+]
+
+
+@pytest.mark.parametrize("case", UPLOAD_CASES, ids=[case["name"] for case in UPLOAD_CASES])
+def test_upload_endpoints_accept_files(client, case):
+    files = [
+        (case["field"], (filename, content, content_type))
+        for filename, content, content_type in case["files"]
+    ]
+    response = client.post(case["path"], files=files)
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert "session_id" in payload

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = app/tests
+pythonpath = app


### PR DESCRIPTION
### Motivation

- Provide automated test coverage for the API endpoints used by the PDF processing tools to demonstrate pytest experience.
- Ensure upload and process flows are validated across all tool routers with minimal, framework-level tests.

### Description

- Added `pytest` to `app/requirements.txt` and created `pytest.ini` to configure test discovery under `app/tests`.
- Added `app/tests/conftest.py` with a `client` fixture that uses `fastapi.testclient.TestClient` and overrides `settings.TEMP_DIR` to a temporary path.
- Added endpoint tests: `app/tests/test_tools_uploads.py` (upload endpoints for all tools) and `app/tests/test_tools_process.py` (process endpoints asserting missing sessions return `404`).
- Updated `README.md` with instructions to install requirements and run tests using `pytest`.

### Testing

- New automated tests were added under `app/tests` covering uploads and missing-session `process` behavior for each tool endpoint.
- Test fixture `client` isolates filesystem by setting `settings.TEMP_DIR` to a pytest `tmp_path` via `conftest.py`.
- No automated test run was executed as part of this change (tests were added but not run in CI or locally during the rollout).
- To run tests locally, install dependencies and run `pytest` as described in the updated `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cf8503c44832782e8dae926ea8727)